### PR TITLE
Feature/tool bar view

### DIFF
--- a/PhotoTodo.xcodeproj/project.pbxproj
+++ b/PhotoTodo.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		1A2E5C8A2C5C617D00BAFD13 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E5C892C5C617D00BAFD13 /* TabBarView.swift */; };
 		1A2E5C8C2C5C643600BAFD13 /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E5C8B2C5C643600BAFD13 /* TestView.swift */; };
 		61E6D71A2C5E443D00C22046 /* ToolBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E6D7192C5E443D00C22046 /* ToolBarView.swift */; };
+		61E6D71C2C5E5EA700C22046 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E6D71B2C5E5EA700C22046 /* ImagePicker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +55,7 @@
 		1A2E5C892C5C617D00BAFD13 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		1A2E5C8B2C5C643600BAFD13 /* TestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };
 		61E6D7192C5E443D00C22046 /* ToolBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolBarView.swift; sourceTree = "<group>"; };
+		61E6D71B2C5E5EA700C22046 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +122,7 @@
 				1A2E5C892C5C617D00BAFD13 /* TabBarView.swift */,
 				1A0D96762C59C8C100784CBA /* Item.swift */,
 				61E6D7192C5E443D00C22046 /* ToolBarView.swift */,
+				61E6D71B2C5E5EA700C22046 /* ImagePicker.swift */,
 				1A0D96812C5A14CC00784CBA /* ViewModel */,
 				1A2472A22C57A79C00A135D9 /* Models */,
 				1A2778E32C56395A00A02C7E /* Assets.xcassets */,
@@ -229,6 +232,7 @@
 				1A0D96832C5A14F300784CBA /* CameraViewModel.swift in Sources */,
 				1A2472A42C57A7CF00A135D9 /* PhotoTodoModel.swift in Sources */,
 				1A0D96852C5A150D00784CBA /* CameraPreview.swift in Sources */,
+				61E6D71C2C5E5EA700C22046 /* ImagePicker.swift in Sources */,
 				1A2778DE2C56395900A02C7E /* PhotoTodoApp.swift in Sources */,
 				1A2778F42C57415900A02C7E /* CameraView.swift in Sources */,
 			);

--- a/PhotoTodo.xcodeproj/project.pbxproj
+++ b/PhotoTodo.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		1A2E5C882C5B990D00BAFD13 /* TodoCompositeGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E5C872C5B990D00BAFD13 /* TodoCompositeGridView.swift */; };
 		1A2E5C8A2C5C617D00BAFD13 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E5C892C5C617D00BAFD13 /* TabBarView.swift */; };
 		1A2E5C8C2C5C643600BAFD13 /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E5C8B2C5C643600BAFD13 /* TestView.swift */; };
+		61E6D71A2C5E443D00C22046 /* ToolBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E6D7192C5E443D00C22046 /* ToolBarView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +53,7 @@
 		1A2E5C872C5B990D00BAFD13 /* TodoCompositeGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoCompositeGridView.swift; sourceTree = "<group>"; };
 		1A2E5C892C5C617D00BAFD13 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		1A2E5C8B2C5C643600BAFD13 /* TestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };
+		61E6D7192C5E443D00C22046 /* ToolBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolBarView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +119,7 @@
 				1A0D96842C5A150D00784CBA /* CameraPreview.swift */,
 				1A2E5C892C5C617D00BAFD13 /* TabBarView.swift */,
 				1A0D96762C59C8C100784CBA /* Item.swift */,
+				61E6D7192C5E443D00C22046 /* ToolBarView.swift */,
 				1A0D96812C5A14CC00784CBA /* ViewModel */,
 				1A2472A22C57A79C00A135D9 /* Models */,
 				1A2778E32C56395A00A02C7E /* Assets.xcassets */,
@@ -213,10 +216,10 @@
 				1A2E5C882C5B990D00BAFD13 /* TodoCompositeGridView.swift in Sources */,
 				1A0D96772C59C8C100784CBA /* Item.swift in Sources */,
 				1A2778E02C56395900A02C7E /* ContentView.swift in Sources */,
-				3C7064912C5C113B00C2770E /* TabBarView.swift in Sources */,
 				1A0D96892C5A156800784CBA /* TodoView.swift in Sources */,
 				1A2778FC2C57719B00A02C7E /* DashBoardView.swift in Sources */,
 				1A2E5C8C2C5C643600BAFD13 /* TestView.swift in Sources */,
+				61E6D71A2C5E443D00C22046 /* ToolBarView.swift in Sources */,
 				1A2E5C842C5B573400BAFD13 /* FolderCarouselView.swift in Sources */,
 				1A2778F82C5741BD00A02C7E /* MainView.swift in Sources */,
 				1A0D96872C5A152A00784CBA /* MakeTodoView.swift in Sources */,
@@ -361,9 +364,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PhotoTodo/Preview Content\"";
-				DEVELOPMENT_TEAM = 4RG9LBF3XF;
+				DEVELOPMENT_TEAM = 2J2UA8CPHM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "TodoItem을 업로드하기 위해 카메라 사용이 필요합니다";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -390,9 +394,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PhotoTodo/Preview Content\"";
-				DEVELOPMENT_TEAM = 4RG9LBF3XF;
+				DEVELOPMENT_TEAM = 2J2UA8CPHM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "TodoItem을 업로드하기 위해 카메라 사용이 필요합니다";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/PhotoTodo/ImagePicker.swift
+++ b/PhotoTodo/ImagePicker.swift
@@ -1,0 +1,49 @@
+//
+//  ImagePicker.swift
+//  PhotoTodo
+//
+//  Created by Hyungeol Lee on 8/3/24.
+//
+
+import PhotosUI
+import SwiftUI
+
+struct ImagePicker: UIViewControllerRepresentable {
+    @Binding var image: UIImage?
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config = PHPickerConfiguration()
+        config.filter = .images
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {
+
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        let parent: ImagePicker
+
+        init(_ parent: ImagePicker) {
+            self.parent = parent
+        }
+
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            picker.dismiss(animated: true)
+
+            guard let provider = results.first?.itemProvider else { return }
+
+            if provider.canLoadObject(ofClass: UIImage.self) {
+                provider.loadObject(ofClass: UIImage.self) { image, _ in
+                    self.parent.image = image as? UIImage
+                }
+            }
+        }
+    }
+}

--- a/PhotoTodo/ToolBarView.swift
+++ b/PhotoTodo/ToolBarView.swift
@@ -8,19 +8,27 @@
 import SwiftUI
 
 struct ToolBarView: View {
+    @State private var showingImagePicker = false
+    @State private var inputImage: UIImage?
     @State var photoData: [Data] = []
+    @State var image = Image(uiImage: UIImage(data: Data()))
     
     var body: some View {
         NavigationView{
             VStack {
                 Text("이미지 업로드")
-                Image(uiImage: UIImage(data: Data()))
+//                Image(uiImage: UIImage(data: Data()))
+                image
+                    .resizable()
+                    .frame(width: 180, height: 200)
+                    .scaledToFit()
             }
             .toolbar{
                 ToolbarItemGroup(placement: .bottomBar) {
                     //TODO: 업로드 창에서 선택 후 이미지 넣기
                     Button {
                         print("tap first button")
+                        showingImagePicker = true
                     } label : {
                         Image(systemName: "photo.on.rectangle")
                     }
@@ -32,6 +40,15 @@ struct ToolBarView: View {
                 }
             }
         }
+        .onChange(of: inputImage) { _ in loadImage() }
+        .sheet(isPresented: $showingImagePicker) {
+            ImagePicker(image: $inputImage)
+        }
+    }
+    
+    func loadImage() {
+        guard let inputImage = inputImage else { return }
+        image = Image(uiImage: inputImage)
     }
 }
 

--- a/PhotoTodo/ToolBarView.swift
+++ b/PhotoTodo/ToolBarView.swift
@@ -1,0 +1,41 @@
+//
+//  ToolBarView.swift
+//  PhotoTodo
+//
+//  Created by Hyungeol Lee on 8/3/24.
+//
+
+import SwiftUI
+
+struct ToolBarView: View {
+    @State var photoData: [Data] = []
+    
+    var body: some View {
+        NavigationView{
+            VStack {
+                Text("이미지 업로드")
+                Image(uiImage: UIImage(data: Data()))
+            }
+            .toolbar{
+                ToolbarItemGroup(placement: .bottomBar) {
+                    //TODO: 업로드 창에서 선택 후 이미지 넣기
+                    Button {
+                        print("tap first button")
+                    } label : {
+                        Image(systemName: "photo.on.rectangle")
+                    }
+                    NavigationLink {
+                        CameraView()
+                    }label: {
+                        Image(systemName: "camera")
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ToolBarView()
+    
+}


### PR DESCRIPTION
## 툴바 뷰 생성
`MakeTodoView`의 하단에 들어갈 툴바 뷰를 생성했습니다. 
<img width="541" alt="image" src="https://github.com/user-attachments/assets/20b52f18-bfdb-46f5-9ea4-48191f11801d">


## 이미지 피커 생성
왼쪽의 이미지 업로드 버튼을 누르면 이미지 피커 화면이 뜹니다.
<img width="486" alt="image" src="https://github.com/user-attachments/assets/5491c211-ae5e-41ea-88bf-8cf90587b3dc">

오른쪽의 카메라 버튼을 누르면 카메라로 전환되어서, 기존에 있는 이미지에 추가를 할 수 있도록 하는 작업이 이어져야 할 것 같습니다. 그렇게 이어지도록 코드가 수정될 수 있을지 논의가 필요합니다.

또, `TodoGridView`의 네비게이션 바의 '+' 버튼을 누를 때 `MakeTodoView`로 전환되는 기능도 필요해 보입니다. 