### PR TITLE
Feature/todo grid view

### DIFF
--- a/PhotoTodo/CameraView.swift
+++ b/PhotoTodo/CameraView.swift
@@ -22,14 +22,14 @@ struct CameraView: View {
     @State private var cameraCaptureState: CameraCaptureState = .single
     @State private var cameraCaptureisActive = false
     @State private var photoData: [Data] = []
-    @State private var contentAlarm = Date()
-    @State private var memo: String = ""
-    @State private var alarmDataisEmpty: Bool = true
+    @State private var contentAlarm: Date? = Date()
+    @State private var memo: String? = ""
+    @State private var alarmDataisEmpty: Bool? = true
     
     // 폴더 관련
     @State var chosenFolder: Folder? = nil
     @Query private var folders: [Folder]
-    @State private var home: Bool = false
+    @State private var home: Bool? = false
     @State private var lastScale: CGFloat = 1.0
     
     var body: some View {
@@ -131,6 +131,7 @@ struct CameraView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .onAppear(perform: {
+            guard let home = home else {return}
             if home {
                 dismiss()
             }

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -31,10 +31,18 @@ struct MakeTodoView: View {
     @State private var memoisActive: Bool = false
     @Binding var memo: String
     @Query private var folders: [Folder]
-    @State private var chosenFolderName: String = "기본폴더"
-    @State private var chosenFolderColor: Color = Color.red
+//    @State private var chosenFolderName: String = "기본폴더"
+//    @State private var chosenFolderColor: Color = Color.red
     @Binding var home: Bool
-
+    
+    
+    var chosenFolderColor : Color{
+        return chosenFolder != nil ? changeStringToColor(colorName: chosenFolder?.color ?? "green") : changeStringToColor(colorName: folders[0].color)
+    }
+    var chosenFolderName : String{
+        return chosenFolder != nil ? chosenFolder!.name : folders[0].name
+    }
+    
     var body: some View {
         
         VStack(alignment: .center){
@@ -67,8 +75,8 @@ struct MakeTodoView: View {
                                 ForEach(folders, id: \.self.id){ folder in
                                     Button(action: {
                                         chosenFolder = folder
-                                        chosenFolderName = folder.name
-                                        chosenFolderColor = changeStringToColor(colorName: folder.color)
+//                                        chosenFolderName = folder.name
+//                                        chosenFolderColor = changeStringToColor(colorName: folder.color)
                                     }) {
                                         Label("\(folder.name)", systemImage: "circle")
                                     }
@@ -188,8 +196,8 @@ struct MakeTodoView: View {
         }
         .onAppear(perform: {
 //            print(chosenFolder.name ??")
-            chosenFolderName = chosenFolder?.name ?? ""
-            chosenFolderColor = changeStringToColor(colorName: chosenFolder?.color ?? "Yellow")
+//            chosenFolderName = chosenFolder?.name ?? ""
+//            chosenFolderColor = changeStringToColor(colorName: chosenFolder?.color ?? "Yellow")
             if startViewType == .edit {
             }
         })
@@ -205,8 +213,12 @@ struct MakeTodoView: View {
 //                    modelContext.insert(newTodo)
 //                }
                 
-                let newTodo: Todo = Todo(folder: chosenFolder, id: UUID(), image: cameraVM.photoData.first ?? Data(), createdAt: Date(), options: Options(alarm: contentAlarm, memo: memo), isDone: false)
-                chosenFolder!.todos.append(newTodo)
+                let newTodo: Todo = Todo(folder: chosenFolder, id: UUID(), image: cameraVM.photoData.first ?? Data(), createdAt: Date(), options: Options(alarm: alarmDataisEmpty ? nil : contentAlarm, memo: memo), isDone: false)
+                if let chosenFolder = chosenFolder {
+                    chosenFolder.todos.append(newTodo)
+                } else {
+                    folders[0].todos.append(newTodo)
+                }
                 modelContext.insert(newTodo)
                 home = true
                 dismiss()

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -33,8 +33,6 @@ struct MakeTodoView: View {
     @State private var memoisActive: Bool = false
     @Binding var memo: String?
     @Query private var folders: [Folder]
-//    @State private var chosenFolderName: String = "기본폴더"
-//    @State private var chosenFolderColor: Color = Color.red
     @Binding var home: Bool?
     
     
@@ -196,13 +194,7 @@ struct MakeTodoView: View {
             .scrollContentBackground(.hidden)
             .scrollDisabled(true)
         }
-        .onAppear(perform: {
-//            print(chosenFolder.name ??")
-//            chosenFolderName = chosenFolder?.name ?? ""
-//            chosenFolderColor = changeStringToColor(colorName: chosenFolder?.color ?? "Yellow")
-            if startViewType == .edit {
-            }
-        })
+
         .toolbar(content: {
             Button {
                 //SwiftData 저장 작업

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -34,6 +34,12 @@ struct TodoGridView: View {
     @State private var selectedImages = [Image]()
     @State private var selectedItem: PhotosPickerItem?
     
+    //새로운 사진 업로드 시 MakeTodoView에서 필요한 상태들
+    @State var contentAlarm = Date()
+    @State var memo: String = ""
+    @State var alarmDataisEmpty: Bool = true
+    @State var home: Bool = false
+    
     var todos: [Todo] {
         switch viewType {
         case .singleFolder:
@@ -122,7 +128,7 @@ struct TodoGridView: View {
                 navigationBarTitle
             )
             .navigationDestination(isPresented: $isActive) {
-                MakeTodoView(cameraVM: cameraVM, chosenFolder: $currentFolder, startViewType: .camera)
+                MakeTodoView(cameraVM: cameraVM, chosenFolder: $currentFolder, startViewType: .camera, contentAlarm: $contentAlarm, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
             }
             .toolbar {
                 ToolbarItem {

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -25,6 +25,10 @@ struct TodoGridView: View {
     @State private var editMode: EditMode = .inactive
     @State private var sortOption: SortOption = .byDate
     @State private var isShowingOptions = false
+    @State private var showingImagePicker = false
+    @State private var inputImage: UIImage?
+    @State private var isActive = false
+    @StateObject var cameraVM: CameraViewModel = CameraViewModel()
     @AppStorage("deletionCount") var deletionCount: Int = 0
     
     var todos: [Todo] {
@@ -105,16 +109,16 @@ struct TodoGridView: View {
                 } label : {
                     Text("촬영하기")
                 }
-//                Button("촬영하기"){
-//                    addTodos()
-//                }
                 Button("앨범에서 가져오기"){
-                    print("앨범에서 가져오기")
+                    showingImagePicker.toggle()
                 }
             }
             .navigationBarTitle(
                 navigationBarTitle
             )
+            .navigationDestination(isPresented: $isActive) {
+               //TODO: Navigate 되게 하기
+            }
             .toolbar {
                 ToolbarItem {
                     editMode == .active ?
@@ -137,6 +141,10 @@ struct TodoGridView: View {
                         }
                 }
             }
+            .sheet(isPresented: $showingImagePicker) {
+                ImagePicker(image: $inputImage)
+            }
+            .onChange(of: inputImage) { _ in loadImage() }
             .environment(\.editMode, $editMode)
         }
     }
@@ -190,6 +198,14 @@ struct TodoGridView: View {
                 selectedTodos.removeAll() // Clear selected items after deletion
             }
         }
+    }
+    
+    ///a method that will be called when the ImagePicker view has been dismissed
+    func loadImage() {
+        guard let inputImage = inputImage else { return }
+        cameraVM.photoData.append(inputImage.pngData() ?? Data())
+        print(cameraVM.photoData)
+        isActive = true
     }
 }
 

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -127,6 +127,7 @@ struct TodoGridView: View {
             .navigationBarTitle(
                 navigationBarTitle
             )
+            //PhotosPicker에서 아이템 선택 완료 시, isActive가 true로 바뀌고, MakeTodoView로 전환됨
             .navigationDestination(isPresented: $isActive) {
                 MakeTodoView(cameraVM: cameraVM, chosenFolder: $currentFolder, startViewType: viewType == .singleFolder ? .gridSingleFolder : .gridMain , contentAlarm: $contentAlarm, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
             }
@@ -152,11 +153,6 @@ struct TodoGridView: View {
                         }
                 }
             }
-//            .sheet(isPresented: $showingImagePicker) {
-//                ImagePicker(image: $inputImage)
-////                PhotosPicker("Select images", selection: $selectedItems, matching: .images)
-//            }
-
             .environment(\.editMode, $editMode)
         }
     }
@@ -216,20 +212,12 @@ struct TodoGridView: View {
     func loadImage() {
         Task {
             guard let imageData = try await selectedItem?.loadTransferable(type: Data.self) else { return }
-//            guard let inputImage = UIImage(data: imageData) else { return }
             cameraVM.photoData.append(imageData)
             selectedItem = nil
             isActive = true
         }
     }
     
-    ///a method that will be called when the ImagePicker view has been dismissed
-//    func loadImage2() {
-//        guard let inputImage = inputImage else { return }
-//        cameraVM.photoData.append(UIImage(selectedImages[0]).pngData() ?? Data())
-//        print(cameraVM.photoData)
-//        isActive = true
-//    }
 }
 
 

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import SwiftData
 import UIKit
+import PhotosUI
 
 enum SortOption {
     case byDate
@@ -30,6 +31,8 @@ struct TodoGridView: View {
     @State private var isActive = false
     @StateObject var cameraVM: CameraViewModel = CameraViewModel()
     @AppStorage("deletionCount") var deletionCount: Int = 0
+    @State private var selectedItems = [PhotosPickerItem]()
+    @State private var selectedImages = [Image]()
     
     var todos: [Todo] {
         switch viewType {
@@ -113,6 +116,7 @@ struct TodoGridView: View {
                     showingImagePicker.toggle()
                 }
             }
+            .photosPicker(isPresented: $showingImagePicker, selection: $selectedItems)
             .navigationBarTitle(
                 navigationBarTitle
             )
@@ -141,9 +145,10 @@ struct TodoGridView: View {
                         }
                 }
             }
-            .sheet(isPresented: $showingImagePicker) {
-                ImagePicker(image: $inputImage)
-            }
+//            .sheet(isPresented: $showingImagePicker) {
+//                ImagePicker(image: $inputImage)
+////                PhotosPicker("Select images", selection: $selectedItems, matching: .images)
+//            }
             .onChange(of: inputImage) { _ in loadImage() }
             .environment(\.editMode, $editMode)
         }

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -35,10 +35,10 @@ struct TodoGridView: View {
     @State private var selectedItem: PhotosPickerItem?
     
     //새로운 사진 업로드 시 MakeTodoView에서 필요한 상태들
-    @State var contentAlarm = Date()
-    @State var memo: String = ""
-    @State var alarmDataisEmpty: Bool = true
-    @State var home: Bool = false
+    @State var contentAlarm: Date? = nil
+    @State var memo: String? = nil
+    @State var alarmDataisEmpty: Bool? = nil
+    @State var home: Bool? = nil
     
     var todos: [Todo] {
         switch viewType {
@@ -128,7 +128,7 @@ struct TodoGridView: View {
                 navigationBarTitle
             )
             .navigationDestination(isPresented: $isActive) {
-                MakeTodoView(cameraVM: cameraVM, chosenFolder: $currentFolder, startViewType: .camera, contentAlarm: $contentAlarm, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
+                MakeTodoView(cameraVM: cameraVM, chosenFolder: $currentFolder, startViewType: viewType == .singleFolder ? .gridSingleFolder : .gridMain , contentAlarm: $contentAlarm, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
             }
             .toolbar {
                 ToolbarItem {
@@ -218,6 +218,7 @@ struct TodoGridView: View {
             guard let imageData = try await selectedItem?.loadTransferable(type: Data.self) else { return }
 //            guard let inputImage = UIImage(data: imageData) else { return }
             cameraVM.photoData.append(imageData)
+            selectedItem = nil
             isActive = true
         }
     }

--- a/PhotoTodo/TodoItemView.swift
+++ b/PhotoTodo/TodoItemView.swift
@@ -17,11 +17,11 @@ struct TodoItemView: View {
     // TodoGridView에서 해당하는 todo를 넘겨받음
     var todo: Todo
     @State private var chosenFolder: Folder? = Folder(id: UUID(), name: "기본폴더", color: "red", todos: [])
-    @State private var contentAlarm = Date()
-    @State private var memo: String = ""
-    @State private var alarmDataisEmpty: Bool = true
+    @State private var contentAlarm: Date? = Date()
+    @State private var memo: String? = ""
+    @State private var alarmDataisEmpty: Bool? = true
     @State private var path: NavigationPath = NavigationPath()
-    @State private var home: Bool = false
+    @State private var home: Bool? = false
     
     var body: some View {
         ZStack{
@@ -74,7 +74,7 @@ struct TodoItemView: View {
                         }
                         Spacer()
                         Button {
-                            if !alarmDataisEmpty {
+                            if alarmDataisEmpty != nil && !alarmDataisEmpty! {
                                 let todoData = Todo(folder: chosenFolder, id: todo.id, image: todo.image, createdAt: todo.createdAt, options: Options(alarm: contentAlarm, memo: memo), isDone: todo.isDone)
                                 modelContext.insert(todoData)
                                 print("알람 데이터 있음")


### PR DESCRIPTION
## 앨범에서 가져오기 기능
- 아래 액션 시트의 '앨범에서 가져오기' 기능을 구현하였습니다.
<img width="267" alt="image" src="https://github.com/user-attachments/assets/70832409-7411-45b0-b1a9-839a276e5e6d">


## 변경사항
- `TodoGridView`에 다음과 같은 상태가 추가되었습니다.
```Swift
    //새로운 사진 업로드 시 MakeTodoView에서 필요한 상태들
    @State var contentAlarm: Date? = nil
    @State var memo: String? = nil
    @State var alarmDataisEmpty: Bool? = nil
    @State var home: Bool? = nil
```

- `MakeTodoView`의 `contentAlarm`, `memo`, `alarmDataIsEmpty`, `home` 변수들을 옵셔널 타입으로 변경하였습니다. 이러한 변화에 따르는 엣지 케이스 처리를 추가하였습니다.
 
- `Binding`에 관한 extension을 추가하였습니다. 넘어온 `State`값이 `nil`일 때 default값을 넣어 사용할 수 있습니다. 옵셔널이 아닌 타입 바인딩이 요구되는 곳에서 유용하게 사용할 수 있었습니다.
```Swift
extension Binding {
  func withDefault<T>(_ defaultValue: T) -> Binding<T> where Value == Optional<T> {
    return Binding<T>(get: {
      self.wrappedValue ?? defaultValue
    }, set: { newValue in
      self.wrappedValue = newValue
    })
  }
}

//예시
selection: $contentAlarm.withDefault(Date())
```

## 시연영상

https://github.com/user-attachments/assets/f9c5ce17-fb71-4dd7-ae9e-0dea8fca1cb2




