### PR TITLE
Feat: [feature/TodoGridView] 메인화면에서 날짜별로 투두 아이템 그룹핑한 뷰로 재구성

### DIFF
--- a/PhotoTodo.xcodeproj/project.pbxproj
+++ b/PhotoTodo.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		1A2E5C8A2C5C617D00BAFD13 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E5C892C5C617D00BAFD13 /* TabBarView.swift */; };
 		1A2E5C8C2C5C643600BAFD13 /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E5C8B2C5C643600BAFD13 /* TestView.swift */; };
 		1A2E5C902C634BAE00BAFD13 /* DoneListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E5C8F2C634BAE00BAFD13 /* DoneListView.swift */; };
+		1AFB127E2C69C22D00952121 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 1AFB127D2C69C22D00952121 /* Collections */; };
 		3C90390D2C623EFF00025335 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C90390C2C623EFF00025335 /* Date+Extension.swift */; };
 		3CC1139B2C69169B00281EBD /* UserNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC1139A2C69169A00281EBD /* UserNotification.swift */; };
 		4F46B28B2C5C7E2100556646 /* FolderEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F46B28A2C5C7E2100556646 /* FolderEditView.swift */; };
@@ -73,6 +74,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1AFB127E2C69C22D00952121 /* Collections in Frameworks */,
 				1A2E5C822C5B557200BAFD13 /* SkeletonUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -172,6 +174,7 @@
 			name = PhotoTodo;
 			packageProductDependencies = (
 				1A2E5C812C5B557200BAFD13 /* SkeletonUI */,
+				1AFB127D2C69C22D00952121 /* Collections */,
 			);
 			productName = "2024-MC3-A05-PhotoTodo";
 			productReference = 1A2778DA2C56395900A02C7E /* PhotoTodo.app */;
@@ -203,6 +206,7 @@
 			mainGroup = 1A2778D12C56395900A02C7E;
 			packageReferences = (
 				1A2E5C802C5B557200BAFD13 /* XCRemoteSwiftPackageReference "SkeletonUI" */,
+				1AFB127C2C69C22D00952121 /* XCRemoteSwiftPackageReference "swift-collections" */,
 			);
 			productRefGroup = 1A2778DB2C56395900A02C7E /* Products */;
 			projectDirPath = "";
@@ -388,7 +392,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PhotoTodo/Preview Content\"";
-				DEVELOPMENT_TEAM = 4RG9LBF3XF;
+				DEVELOPMENT_TEAM = 2J2UA8CPHM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "TodoItem을 업로드하기 위해 카메라 사용이 필요합니다";
@@ -402,7 +406,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "environmentalistsTodo.-024-MC3-A05-PhotoTodo";
+				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -418,7 +422,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PhotoTodo/Preview Content\"";
-				DEVELOPMENT_TEAM = 4RG9LBF3XF;
+				DEVELOPMENT_TEAM = 2J2UA8CPHM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "TodoItem을 업로드하기 위해 카메라 사용이 필요합니다";
@@ -432,7 +436,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "environmentalistsTodo.-024-MC3-A05-PhotoTodo";
+				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -472,6 +476,14 @@
 				minimumVersion = 2.0.2;
 			};
 		};
+		1AFB127C2C69C22D00952121 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-collections.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -479,6 +491,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 1A2E5C802C5B557200BAFD13 /* XCRemoteSwiftPackageReference "SkeletonUI" */;
 			productName = SkeletonUI;
+		};
+		1AFB127D2C69C22D00952121 /* Collections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1AFB127C2C69C22D00952121 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = Collections;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/PhotoTodo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PhotoTodo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "720a96f1b624fba16d661f1a429e5e7479d54f039581bba1a2429ac81e55a3fe",
+  "originHash" : "7042574d4113ac7d7a1b93aa70ef901281a77554b94ab353f19492544452d273",
   "pins" : [
     {
       "identity" : "skeletonui",
@@ -11,12 +11,21 @@
       }
     },
     {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
+        "version" : "1.1.2"
+      }
+    },
+    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "c097f955b4e724690f0fc8ffb7a6d4b881c9c4e3",
-        "version" : "1.17.2"
+        "revision" : "6d932a79e7173b275b96c600c86c603cf84f153c",
+        "version" : "1.17.4"
       }
     },
     {

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -265,7 +265,11 @@ struct TodoGridView: View {
     var groupedGridView: some View {
         ForEach(todosGroupedByDate.indices, id: \.self) { groupIndex in
             VStack{
-                Text(getDateString(todosGroupedByDate[groupIndex][0].createdAt))
+                HStack{
+                    Text(getDateString(todosGroupedByDate[groupIndex][0].createdAt))
+                        .foregroundStyle(.gray)
+                    Spacer()
+                }.padding(.leading)
                 gridView(sortedTodos: todosGroupedByDate[groupIndex], toastMessage: $toastMessage, toastOption: $toastOption, selectedTodos: $selectedTodos, editMode: $editMode)
             }
         }
@@ -314,7 +318,7 @@ struct TodoGridView: View {
                 currDate = dayOfYear(from : sortedTodos[i].createdAt)
             case .byDueDate:
                 currDate = dayOfYear(from : sortedTodos[i].options.alarm ?? Date())
-            default:
+            default: //그룹화는 만들어진 날짜를 기준으로 이루어짐
                 currDate = dayOfYear(from : sortedTodos[i].createdAt)
             }
             groupedTodos[currDate, default: []].append(sortedTodos[i])
@@ -410,8 +414,8 @@ private struct toastView: View {
     }
 }
 
-private struct gridView: View {
-    @State var sortedTodos: [Todo]
+ struct gridView: View {
+    var sortedTodos: [Todo]
     @Binding var toastMessage: Todo?
     @Binding var toastOption: ToastOption
     @Binding var selectedTodos: Set<UUID>

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -9,11 +9,13 @@ import SwiftUI
 import SwiftData
 import UIKit
 import PhotosUI
+import OrderedCollections
 
 enum SortOption {
     case byDate
     case byName
     case byStatus
+    case byDueDate
 }
 
 enum ToastOption {
@@ -50,10 +52,11 @@ struct TodoGridView: View {
     @State var alarmID: String? = nil
     
     // 토글버튼에 따라서 토스트 메시지 설정 변수
-    @State private var toastMassage: Todo? = nil
+    @State private var toastMessage: Todo? = nil
     @State private var toastOption: ToastOption = .none
 
     @State private var alarmSetting: Bool = false
+    
     
     var todos: [Todo] {
         switch viewType {
@@ -81,14 +84,17 @@ struct TodoGridView: View {
             return todos.sorted { $0.options.memo ?? "" < $1.options.memo ?? "" }
         case .byStatus:
             return todos.sorted { $0.isDone && !$1.isDone }
+        case .byDueDate:
+            return todos.sorted { $0.options.alarm ?? Date() < $1.options.alarm ?? Date() }
+            
         }
     }
     //TODO: folder.todos를 여러 옵션으로 정렬하기
     
-    let columns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-    ]
+    var todosGroupedByDate: [[Todo]] {
+        return Array(getTodosGroupedByDate().values)
+    }
+    
     
     var navigationBarTitle: String {
         switch viewType {
@@ -250,32 +256,18 @@ struct TodoGridView: View {
             if viewType == .main {
                 customTitle
             }
+            viewType != .main ? 
+            AnyView(gridView(sortedTodos: sortedTodos, toastMessage: $toastMessage, toastOption: $toastOption, selectedTodos: $selectedTodos, editMode: $editMode)) :
+            AnyView(groupedGridView)
+        }
+    }
+    
+    var groupedGridView: some View {
+        ForEach(todosGroupedByDate.indices, id: \.self) { groupIndex in
             VStack{
-                LazyVGrid(columns: columns, spacing: 12) {
-                    //TODO: 이미지 비율 맞추기
-                    ForEach(sortedTodos) { todo in
-                        TodoItemView(editMode: $editMode, todo: todo, toastMessage: $toastMassage, toastOption: $toastOption)
-                        //tap gesture로 선택되었을 시 라인으로 표시됨
-                            .overlay(
-                                    RoundedRectangle(cornerRadius: 20)
-                                        .stroke(selectedTodos.contains(todo.id) ? Color("green/green-500") : Color.clear, lineWidth: 4)
-                            )
-                        //편집모드가 활성화되어 있을 시 tap gesture로 여러 아이템을 선택할 수 있게 함
-                            .onTapGesture {
-                                if editMode == .active {
-                                    if selectedTodos.contains(todo.id) {
-                                        selectedTodos.remove(todo.id)
-                                    } else {
-                                        selectedTodos.insert(todo.id)
-                                    }
-                                }
-                            }
-                    }
-                }
-                .padding(.bottom)
+                Text(getDateString(todosGroupedByDate[groupIndex][0].createdAt))
+                gridView(sortedTodos: todosGroupedByDate[groupIndex], toastMessage: $toastMessage, toastOption: $toastOption, selectedTodos: $selectedTodos, editMode: $editMode)
             }
-            .padding(.horizontal)
-            
         }
     }
     
@@ -303,6 +295,33 @@ struct TodoGridView: View {
         .padding()
     }
     
+    private func getDateString(_ date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM월 d일"
+        return dateFormatter.string(from: date)
+    }
+    
+    private func getTodosGroupedByDate() -> OrderedDictionary<Int, [Todo]> {
+        if sortedTodos.count == 0 {
+            return [dayOfYear(from : Date()): sortedTodos]
+        }
+        var groupedTodos: OrderedDictionary<Int, [Todo]> = [:]
+        var i = 0
+        var currDate: Int
+        while i != sortedTodos.count {
+            switch sortOption {
+            case .byDate:
+                currDate = dayOfYear(from : sortedTodos[i].createdAt)
+            case .byDueDate:
+                currDate = dayOfYear(from : sortedTodos[i].options.alarm ?? Date())
+            default:
+                currDate = dayOfYear(from : sortedTodos[i].createdAt)
+            }
+            groupedTodos[currDate, default: []].append(sortedTodos[i])
+            i += 1
+        }
+        return groupedTodos
+    }
     
     private func toggleAddOptions(){
         isShowingOptions.toggle()
@@ -365,7 +384,6 @@ struct TodoGridView: View {
             isActive = true
         }
     }
-    
 }
 
 private struct toastView: View {
@@ -390,7 +408,47 @@ private struct toastView: View {
                 .offset(y: 250)
         }
     }
+}
+
+private struct gridView: View {
+    @State var sortedTodos: [Todo]
+    @Binding var toastMessage: Todo?
+    @Binding var toastOption: ToastOption
+    @Binding var selectedTodos: Set<UUID>
+    @Binding var editMode: EditMode
     
+    let columns = [
+        GridItem(.flexible()),
+        GridItem(.flexible()),
+    ]
+    
+    var body: some View {
+        VStack{
+            LazyVGrid(columns: columns, spacing: 12) {
+                //TODO: 이미지 비율 맞추기
+                ForEach(sortedTodos) { todo in
+                    TodoItemView(editMode: $editMode, todo: todo, toastMessage: $toastMessage, toastOption: $toastOption)
+                    //tap gesture로 선택되었을 시 라인으로 표시됨
+                        .overlay(
+                                RoundedRectangle(cornerRadius: 20)
+                                    .stroke(selectedTodos.contains(todo.id) ? Color("green/green-500") : Color.clear, lineWidth: 4)
+                        )
+                    //편집모드가 활성화되어 있을 시 tap gesture로 여러 아이템을 선택할 수 있게 함
+                        .onTapGesture {
+                            if editMode == .active {
+                                if selectedTodos.contains(todo.id) {
+                                    selectedTodos.remove(todo.id)
+                                } else {
+                                    selectedTodos.insert(todo.id)
+                                }
+                            }
+                        }
+                }
+            }
+            .padding(.bottom)
+        }
+        .padding(.horizontal)
+    }
 }
 
 

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -110,23 +110,23 @@ struct TodoGridView: View {
     
     var body: some View {
         VStack{
-            viewType == .main ? AnyView(customNavBar) : AnyView(EmptyView())
+            viewType == .main ? AnyView(CustomNavBar) : AnyView(EmptyView())
         }
         ZStack {
             VStack{
                 todos.isEmpty && viewType != .doneList
                 ?
-                AnyView(guideLineView)
+                AnyView(GuideLineView)
                 :
-                AnyView(scrollView)
+                AnyView(ScrollView)
 
             }
             VStack{
                 if toastOption == .moveToDone {
-                    toastView(toastOption: .moveToDone, toastMessage: "투두가 완료되었어요!")
+                    ToastView(toastOption: .moveToDone, toastMessage: "투두가 완료되었어요!")
                     
                 } else if toastOption == .moveToOrigin {
-                    toastView(toastOption: .moveToOrigin, toastMessage: "투두가 복구되었어요!")
+                    ToastView(toastOption: .moveToOrigin, toastMessage: "투두가 복구되었어요!")
                 }
                 //                if toastMassage == nil {
                 //                    Text("복구되었을 때")
@@ -183,7 +183,7 @@ struct TodoGridView: View {
         .environment(\.editMode, $editMode)
     }
     
-    var customNavBar: some View {
+    var CustomNavBar: some View {
         HStack{
             Button(action: {
                 alarmSetting.toggle()
@@ -226,10 +226,10 @@ struct TodoGridView: View {
     }
     
     
-    var guideLineView: some View {
+    var GuideLineView: some View {
         VStack{
             if viewType == .main {
-                customTitle
+                CustomTitle
             }
             Spacer()
             VStack{
@@ -251,19 +251,19 @@ struct TodoGridView: View {
     }
     
     
-    var scrollView: some View {
-        ScrollView {
+    var ScrollView: some View {
+        SwiftUI.ScrollView {
             if viewType == .main {
-                customTitle
+                CustomTitle
             }
             viewType != .main ? //메인뷰가 아닐 때는 그리드 뷰 하나로 모든 아이템을 모아서 보여줌
-            AnyView(gridView(sortedTodos: sortedTodos, toastMessage: $toastMessage, toastOption: $toastOption, selectedTodos: $selectedTodos, editMode: $editMode)) :
-            AnyView(groupedGridView)  //메인뷰일 때는 날짜별로 그룹화된 아이템을 보여줌
+            AnyView(GridView(sortedTodos: sortedTodos, toastMessage: $toastMessage, toastOption: $toastOption, selectedTodos: $selectedTodos, editMode: $editMode)) :
+            AnyView(GroupedGridView)  //메인뷰일 때는 날짜별로 그룹화된 아이템을 보여줌
         }
     }
     
     /// 날짜별로 그룹화된 아이템들의 각 그룹 각각에 대응하는 그리드 뷰가  ForEach문으로 그려짐
-    var groupedGridView: some View {
+    var GroupedGridView: some View {
         ForEach(todosGroupedByDate.indices, id: \.self) { groupIndex in
             VStack{
                 HStack{
@@ -271,12 +271,12 @@ struct TodoGridView: View {
                         .foregroundStyle(.gray)
                     Spacer()
                 }.padding(.leading)
-                gridView(sortedTodos: todosGroupedByDate[groupIndex], toastMessage: $toastMessage, toastOption: $toastOption, selectedTodos: $selectedTodos, editMode: $editMode)
+                GridView(sortedTodos: todosGroupedByDate[groupIndex], toastMessage: $toastMessage, toastOption: $toastOption, selectedTodos: $selectedTodos, editMode: $editMode)
             }
         }
     }
     
-    var customTitle: some View {
+    var CustomTitle: some View {
         VStack{
             HStack{
                 Text("해야 할 일이")
@@ -392,7 +392,7 @@ struct TodoGridView: View {
     }
 }
 
-private struct toastView: View {
+private struct ToastView: View {
     @State var toastOption: ToastOption
     @State var toastMessage: String
     
@@ -416,7 +416,7 @@ private struct toastView: View {
     }
 }
 
- struct gridView: View {
+ struct GridView: View {
     var sortedTodos: [Todo]
     @Binding var toastMessage: Todo?
     @Binding var toastOption: ToastOption

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -256,12 +256,13 @@ struct TodoGridView: View {
             if viewType == .main {
                 customTitle
             }
-            viewType != .main ? 
+            viewType != .main ? //메인뷰가 아닐 때는 그리드 뷰 하나로 모든 아이템을 모아서 보여줌
             AnyView(gridView(sortedTodos: sortedTodos, toastMessage: $toastMessage, toastOption: $toastOption, selectedTodos: $selectedTodos, editMode: $editMode)) :
-            AnyView(groupedGridView)
+            AnyView(groupedGridView)  //메인뷰일 때는 날짜별로 그룹화된 아이템을 보여줌
         }
     }
     
+    /// 날짜별로 그룹화된 아이템들의 각 그룹 각각에 대응하는 그리드 뷰가  ForEach문으로 그려짐
     var groupedGridView: some View {
         ForEach(todosGroupedByDate.indices, id: \.self) { groupIndex in
             VStack{
@@ -305,11 +306,12 @@ struct TodoGridView: View {
         return dateFormatter.string(from: date)
     }
     
+    /// 날짜별로 투두 아이템을 그루핑한 배열을 모은 배열을 리턴함
     private func getTodosGroupedByDate() -> OrderedDictionary<Int, [Todo]> {
         if sortedTodos.count == 0 {
-            return [dayOfYear(from : Date()): sortedTodos]
+            return [dayOfYear(from : Date()): sortedTodos] //dayOfYear는 현재 연도의 몇번째 날짜인지를 리턴함
         }
-        var groupedTodos: OrderedDictionary<Int, [Todo]> = [:]
+        var groupedTodos: OrderedDictionary<Int, [Todo]> = [:] //OrderedDictionary 타입을 사용하여
         var i = 0
         var currDate: Int
         while i != sortedTodos.count {

--- a/PhotoTodo/TodoItemView.swift
+++ b/PhotoTodo/TodoItemView.swift
@@ -46,7 +46,7 @@ struct TodoItemView: View {
                     .overlay(alignment: .bottomTrailing){
                         RoundedRectangle(cornerRadius: 35)
                             .fill(todo.isDone ? .paleGray : Color.clear)
-                            .opacity(0.5)
+                            .opacity(0.8)
                             .frame(width: 100, height: 40)
                             .overlay {
                                 Text(todo.isDone ? "\(dayOfYear(from : Date())-dayOfYear(from : todo.isDoneAt ?? Date())+30)일남음" : "")


### PR DESCRIPTION
## 날짜별 그룹핑
`getTodosGroupedByDate ` 함수로, 날짜별로 그루핑된 투두 아이템의 배열을 받아, main화면일 경우 각 그룹별로 그리드 뷰를 보여줍니다. main화면이 아닐 경우에는, 하나의 그리드 뷰로 모든 아이템을 보여줍니다. 이를 위해 기존의 `TodoGridView`를 `GridView`와 'ScrollView'로 나누었습니다. `ScrollView ` 안에서, 현재 화면이 main인지 아닌지의 여부에 따라, ForEach문을 돌면서 `GridView`를 보여주거나, 하나의 `GridView`를 보여줍니다.

```Swift
   var ScrollView: some View {
        SwiftUI.ScrollView {
            if viewType == .main {
                CustomTitle
            }
            viewType != .main ? //메인뷰가 아닐 때는 그리드 뷰 하나로 모든 아이템을 모아서 보여줌
            AnyView(GridView(sortedTodos: sortedTodos, toastMessage: $toastMessage, toastOption: $toastOption, selectedTodos: $selectedTodos, editMode: $editMode)) :
            AnyView(GroupedGridView)  //메인뷰일 때는 날짜별로 그룹화된 아이템을 보여줌
        }
    }
```

## 프로젝트 파일 변경
Collections 패키지를 import 해야해서 프로젝트 파일이 변경되었습니다. 추가적으로 테스트 플라이트에 일치하는 팀 아이디와 번들 아이디로 변경되도록 내버려두겠습니다.

## 디자인
조그마한 변경사항들이 있습니다. 커밋 메세지를 참고해주세요.

