### PR TITLE
Fix: [fix/CameraView] 카메라에서 되돌아갈 때 home을 초기화하지 않아 네비게이션 백 되던 오류 수정

### DIFF
--- a/PhotoTodo/CameraView.swift
+++ b/PhotoTodo/CameraView.swift
@@ -132,12 +132,10 @@ struct CameraView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .onAppear(perform: {
-            guard let home = home else {return}
-            if home {
-                dismiss()
-            }
-            // MARK: Preview에 생성이 안되있어서 오류가 날 뿐, 디폴드 폴더는 삭제가 안되게 구현 예정이여서 문제 없습니다.
-            chosenFolder = folders.count != 0 ? folders.first! : nil
+            if home == nil { return }
+            if home! == false { return }
+            home = false
+            dismiss()
         })
         
     }


### PR DESCRIPTION
## 트러블 슈팅
`CameraView`의 기존 코드 중 `onAppera`에서 `dismiss`를 하는 부분에서 `home`이라는 변수를 되돌리는 처리 부분이 없었고, 결국 `dismiss`가 한번 더 일어나면서 navigation 오류가 나는 것처럼 보이는 현상이 있었습니다. 이를 처리해주었고, 오류는 해결된 듯해 보입니다.

### 기존 코드
```Swift 
        .onAppear(perform: {
            guard let home = home else {return}
            if home {
                dismiss()
            }
            // MARK: Preview에 생성이 안되있어서 오류가 날 뿐, 디폴드 폴더는 삭제가 안되게 구현 예정이여서 문제 없습니다.
            chosenFolder = folders.count != 0 ? folders.first! : nil
        })
```

### 수정된 코드
```Swift
.onAppear(perform: {
            if home == nil { return }
            if home! == false { return }
            home = false
            dismiss()
        })
```
