### PR TITLE
Chore: [chore/AlarmSettingView] 색 지정 오류 수정

### DIFF
--- a/PhotoTodo/AlarmSettingView.swift
+++ b/PhotoTodo/AlarmSettingView.swift
@@ -15,7 +15,7 @@ struct AlarmSettingView: View {
     
     var body: some View {
         ZStack{
-            Color("gray-200")
+            Color("gray/gray-200")
                 .ignoresSafeArea()
             
             VStack{


### PR DESCRIPTION
색 지정이 잘못되어 아래와 같은 에러가 나던 부분을 수정하였습니다.

<img width="885" alt="image" src="https://github.com/user-attachments/assets/adafa983-0109-4c56-965f-ef98be769f8b">
