### PR TITLE
Fix: [fix/FolderListView] 폴더 리스트 관련 네비게이션 오류 수정

### DIFF
--- a/PhotoTodo/FolderListView.swift
+++ b/PhotoTodo/FolderListView.swift
@@ -28,7 +28,6 @@ struct FolderListView: View {
     
     
     var body: some View {
-        NavigationStack{
             List {
                 //기본 폴더(인덱스 0에 있음) → 삭제 불가능하게 만들기 위해 따로 뺌
                 NavigationLink{
@@ -81,7 +80,6 @@ struct FolderListView: View {
                 FolderEditView(isSheetPresented: $isShowingSheet, folderNameInput: $folderNameInput, selectedColor: $selectedColor)
                     .presentationDetents([.medium, .large])
             })
-        }
     }
     private func toggleShowingSheet(){
         isShowingSheet.toggle()


### PR DESCRIPTION
## 트러블 슈팅
`FolderListView`에서 폴더 삭제가 제대로 이뤄지지 않는 것처럼 보이는 현상이 있었는데, `TabView`에서 커스텀 탭바로 전환하면서 `NavigationStack`을 `FolderListView`에서 제거해줬어야 했는데 그렇지 않아서 나던 오류였습니다. `NavigationStack`을 제거해주었고, 오류는 해결된 것처럼 보입니다.