### PR TITLE
Fix/todo grid view

### DIFF
--- a/PhotoTodo/MainView.swift
+++ b/PhotoTodo/MainView.swift
@@ -10,9 +10,7 @@ import SwiftUI
 struct MainView: View {
     var viewType: TodoGridViewType = .main
     var body: some View {
-        NavigationStack{
             TodoCompositeGridView(viewType: viewType)
-        }
     }
 }
 

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -239,7 +239,7 @@ struct MakeTodoView: View {
                                 }
                                 
                                 VStack{
-                                    TextField("메모를 입력해주세요.", text: $memo.withDefault(""))
+                                    TextField("메모를 입력해주세요.", text: $memo.withDefault(""), axis: .vertical	)
                                 }.frame(height: 100, alignment: .top)
                                 
                                 Spacer()

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -105,6 +105,7 @@ struct TabBarView: View {
 ////                }
 //                .offset(y: 290)
             }
+            .ignoresSafeArea(.keyboard)
         }
         .onAppear {
             //MARK: 최초 1회 실행된 적이 있을 시

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -91,8 +91,8 @@ struct TodoGridView: View {
     }
     //TODO: folder.todos를 여러 옵션으로 정렬하기
     
-    var todosGroupedByDate: [[Todo]] {
-        return Array(getTodosGroupedByDate().values)
+    var todosGroupedByDate: OrderedDictionary<Int, [Todo]> {
+        return getTodosGroupedByDate()
     }
     
     
@@ -265,14 +265,14 @@ struct TodoGridView: View {
     
     /// 날짜별로 그룹화된 아이템들의 각 그룹 각각에 대응하는 그리드 뷰가  ForEach문으로 그려짐
     var GroupedGridView: some View {
-        ForEach(todosGroupedByDate.indices, id: \.self) { groupIndex in
+        ForEach(todosGroupedByDate.elements, id: \.key) { element in
             VStack{
                 HStack{
-                    Text(getDateString(todosGroupedByDate[groupIndex][0].createdAt))
+                    Text(getDateString(element.value[0].createdAt))
                         .foregroundStyle(.gray)
                     Spacer()
                 }.padding(.leading)
-                GridView(sortedTodos: todosGroupedByDate[groupIndex], toastMessage: $toastMessage, toastOption: $toastOption, selectedTodos: $selectedTodos, editMode: $editMode)
+                GridView(sortedTodos: element.value, toastMessage: $toastMessage, toastOption: $toastOption, selectedTodos: $selectedTodos, editMode: $editMode)
             }
         }
     }

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -314,20 +314,30 @@ struct TodoGridView: View {
         }
         var groupedTodos: OrderedDictionary<Int, [Todo]> = [:] //OrderedDictionary 타입을 사용하여
         var i = 0
-        var currDate: Int
+        var curr: Int
         while i != sortedTodos.count {
             switch sortOption {
             case .byDate:
-                currDate = dayOfYear(from : sortedTodos[i].createdAt)
+                curr = daysPassedSinceJanuaryFirst2024(from : sortedTodos[i].createdAt)
             case .byDueDate:
-                currDate = dayOfYear(from : sortedTodos[i].options.alarm ?? Date())
+                curr = daysPassedSinceJanuaryFirst2024(from : sortedTodos[i].options.alarm ?? Date())
             default: //그룹화는 만들어진 날짜를 기준으로 이루어짐
-                currDate = dayOfYear(from : sortedTodos[i].createdAt)
+                curr = daysPassedSinceJanuaryFirst2024(from : sortedTodos[i].createdAt)
             }
-            groupedTodos[currDate, default: []].append(sortedTodos[i])
+            groupedTodos[curr, default: []].append(sortedTodos[i])
             i += 1
         }
         return groupedTodos
+    }
+    
+    func daysPassedSinceJanuaryFirst2024(from date: Date) -> Int {
+        return dayOfYear(from : date) + (extractYear(from : date)-2024)*365
+    }
+    
+    func extractYear(from date: Date) -> Int {
+        let calendar = Calendar.current
+        let year = calendar.component(.year, from: date)
+        return year
     }
     
     private func toggleAddOptions(){


### PR DESCRIPTION
## 트러블 슈팅
메인화면의 밑부분에서부터 `TextField`를 터치하면 키보드가 열렸다가 사라지는 오류가 있었습니다. `TodoItem`을 중간에서부터 살짝 위로 올린 경우에는, 키보드가 사라지지 않았습니다. 또한 폴더 리스트 뷰에서 들어갔을 때는 문제가 발생하지 않았습니다.

https://github.com/user-attachments/assets/99b9715d-d820-44f0-83b6-66b68505b9d7

## 해결
가장 상위의 뷰인 `TabBarView`에서 `.ignoreSafeArea(.keyboard)` 옵션을 주니 해결되었습니다.

## 의문점
왜 같은 `TodoGridView`를 사용하는데도 불구하고 `FolderListView`에서는 문제가 나타나지 않았는지 의문이 있습니다.

## 추가 변경사항
기존에 작성해둔 날짜별 그룹화 로직의 경우 일 이년 전의 사진이 동일한 그룹에 들어가서 화면에 보여지게 되는데, 추후 문제가 될 것이라 생각하여 로직을 조금 수정하였습니다.