### PR TITLE
Feature/tool bar view 투두 아이템 디테일뷰에서 앨범에서 추가하기 기능 구현

### DIFF
--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -353,6 +353,7 @@ struct MakeTodoView: View {
             }
             
         })
+        .toolbar(.visible, for: .bottomBar)
         .toolbar{
             ToolbarItemGroup(placement: .bottomBar) {
                 //TODO: 업로드 창에서 선택 후 이미지 넣기

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -284,7 +284,7 @@ struct MakeTodoView: View {
                         Spacer()
                         Image(uiImage: clickedImage)
                             .resizable()
-                            .scaledToFill()
+                            .aspectRatio(contentMode: .fit)
                             .frame(width: 350, height: 500)
                             .clipShape(RoundedRectangle(cornerRadius: 25))
                             .scaleEffect(imageScale >= 1.0 ? imageScale : 1.0)

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -286,6 +286,7 @@ struct MakeTodoView: View {
                 }
             }
         }
+        .toolbar(startViewType == .camera ? .visible : .hidden)
         .toolbar(content: {
             Button {
                 //SwiftData 저장 작업
@@ -342,6 +343,22 @@ struct MakeTodoView: View {
             }
             
         })
+        .toolbar{
+            ToolbarItemGroup(placement: .bottomBar) {
+                //TODO: 업로드 창에서 선택 후 이미지 넣기
+                Button {
+                    print("tap first button")
+//                    showingImagePicker = true
+                } label : {
+                    Image(systemName: "photo.on.rectangle")
+                }
+                NavigationLink {
+//                        CameraView()
+                }label: {
+                    Image(systemName: "camera")
+                }
+            }
+        }
     }
     
     func saveImageToAlbum(image: UIImage) {

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -63,9 +63,7 @@ struct MakeTodoView: View {
     
     //이미지 추가 관련 변수들
     @State private var showingImagePicker = false
-    @State private var inputImage: UIImage?
     @State private var selectedItems = [PhotosPickerItem]()
-    @State private var isDoneSelecting: Bool = false
     
     //알람 설정 관련
     @State private var showAlert = false
@@ -398,7 +396,6 @@ struct MakeTodoView: View {
                 }
             }
             selectedItems.removeAll()
-            isDoneSelecting = true
         }
     }
 }

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -287,7 +287,7 @@ struct MakeTodoView: View {
                 }
             }
         }
-        .toolbar(startViewType == .camera ? .visible : .hidden)
+        .toolbar(startViewType == .edit ? .hidden : .visible)
         .toolbar(content: {
             Button {
                 //SwiftData 저장 작업

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -253,6 +253,7 @@ struct MakeTodoView: View {
                 }
                 .scrollContentBackground(.hidden)
                 .scrollDisabled(true)
+                .frame(minHeight: 180)
             }
             if imageClickisActive {
                 ZStack{

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -37,7 +37,7 @@ struct TodoGridView: View {
     @State private var sortOption: SortOption = .byDate
     @State private var isShowingOptions = false
     @State private var showingImagePicker = false
-    @State private var isActive = false
+    @State private var isDoneSelecting = false
     @StateObject var cameraVM: CameraViewModel = CameraViewModel()
     @AppStorage("deletionCount") var deletionCount: Int = 0
     @State private var selectedItems = [PhotosPickerItem]()
@@ -151,7 +151,7 @@ struct TodoGridView: View {
         .navigationTitle(navigationBarTitle)
         .navigationBarHidden( viewType == .main ? true : false)
         //PhotosPicker에서 아이템 선택 완료 시, isActive가 true로 바뀌고, MakeTodoView로 전환됨
-        .navigationDestination(isPresented: $isActive) {
+        .navigationDestination(isPresented: $isDoneSelecting) {
             MakeTodoView(cameraVM: cameraVM, chosenFolder: $currentFolder, startViewType: viewType == .singleFolder ? .gridSingleFolder : .gridMain , contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
         }
         .toolbar {
@@ -401,7 +401,7 @@ struct TodoGridView: View {
                 }
             }
             selectedItems.removeAll()
-            isActive = true
+            isDoneSelecting = true
         }
     }
 }

--- a/PhotoTodo/TodoItemView.swift
+++ b/PhotoTodo/TodoItemView.swift
@@ -117,51 +117,54 @@ struct TodoItemView: View {
             }
             .disabled(editMode == .active)
             .sheet(isPresented: $editTodoisActive, content: {
-                VStack{
-                    HStack{
-                        // 각 아이템을 클릭하면 나오는 디테일 뷰에서 뒤로가기를 할 때 사용되는 버튼
-                        Button {
-                            editTodoisActive.toggle()
-                        } label: {
-                            Text("취소")
-                        }
-                        Spacer()
-                        Button {
-                            
-                            if todo.options.alarmUUID != nil {
-                                manager.deleteNotification(withID: alarmID!)
+                NavigationStack{
+                    VStack{
+                        HStack{
+                            // 각 아이템을 클릭하면 나오는 디테일 뷰에서 뒤로가기를 할 때 사용되는 버튼
+                            Button {
+                                editTodoisActive.toggle()
+                            } label: {
+                                Text("취소")
+                            }
+                            Spacer()
+                            Button {
+                                
+                                if todo.options.alarmUUID != nil {
+                                    manager.deleteNotification(withID: alarmID!)
+                                }
+                                
+                                if alarmDataisEmpty != nil && !alarmDataisEmpty! {
+                                    // 알람 생성
+                                    let calendar = Calendar.current
+                                    let year = calendar.component(.year, from: contentAlarm!)
+                                    let month = calendar.component(.month, from: contentAlarm!)
+                                    let day = calendar.component(.day, from: contentAlarm!)
+                                    let hour = calendar.component(.hour, from: contentAlarm!)
+                                    let minute = calendar.component(.minute, from: contentAlarm!)
+                                    
+                                    // Notification 알람 생성 및 id Todo에 저장하기
+                                    let id = manager.makeTodoNotification(year: year, month: month, day: day, hour: hour, minute: minute)
+                                    
+                                    let todoData = Todo(folder: chosenFolder, id: todo.id, images: todo.images, createdAt: todo.createdAt, options: Options(alarm: contentAlarm, alarmUUID: id, memo: memo), isDone: todo.isDone)
+                                    modelContext.insert(todoData)
+                                    print("알람 데이터 있음")
+                                } else {
+                                    let todoData = Todo(folder: chosenFolder, id: todo.id, images: todo.images, createdAt: todo.createdAt, options: Options(memo: memo), isDone: todo.isDone)
+                                    modelContext.insert(todoData)
+                                    print("알람 데이터 없음")
+                                }
+                                editTodoisActive.toggle()
+                            } label: {
+                                Text("저장")
                             }
                             
-                            if alarmDataisEmpty != nil && !alarmDataisEmpty! {
-                                // 알람 생성
-                                let calendar = Calendar.current
-                                let year = calendar.component(.year, from: contentAlarm!)
-                                let month = calendar.component(.month, from: contentAlarm!)
-                                let day = calendar.component(.day, from: contentAlarm!)
-                                let hour = calendar.component(.hour, from: contentAlarm!)
-                                let minute = calendar.component(.minute, from: contentAlarm!)
-                                
-                                // Notification 알람 생성 및 id Todo에 저장하기
-                                let id = manager.makeTodoNotification(year: year, month: month, day: day, hour: hour, minute: minute)
-                                
-                                let todoData = Todo(folder: chosenFolder, id: todo.id, images: todo.images, createdAt: todo.createdAt, options: Options(alarm: contentAlarm, alarmUUID: id, memo: memo), isDone: todo.isDone)
-                                modelContext.insert(todoData)
-                                print("알람 데이터 있음")
-                            } else {
-                                let todoData = Todo(folder: chosenFolder, id: todo.id, images: todo.images, createdAt: todo.createdAt, options: Options(memo: memo), isDone: todo.isDone)
-                                modelContext.insert(todoData)
-                                print("알람 데이터 없음")
-                            }
-                            editTodoisActive.toggle()
-                        } label: {
-                            Text("저장")
                         }
+                        .padding()
                         
+                        MakeTodoView(chosenFolder: $chosenFolder, startViewType: .edit, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
                     }
-                    .padding()
-                    
-                    MakeTodoView(cameraVM: cameraVM, chosenFolder: $chosenFolder, startViewType: .camera, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
                 }
+                    
             })
 
         }

--- a/PhotoTodo/TodoItemView.swift
+++ b/PhotoTodo/TodoItemView.swift
@@ -33,6 +33,7 @@ struct TodoItemView: View {
     
     var body: some View {
         ZStack{
+            //TodoItemView는 하나의 버튼임
             Button {
                 editTodoisActive.toggle()
                 cameraVM.photoData = todo.images
@@ -127,8 +128,8 @@ struct TodoItemView: View {
                                 Text("취소")
                             }
                             Spacer()
+                            // 저장 버튼
                             Button {
-                                
                                 if todo.options.alarmUUID != nil {
                                     manager.deleteNotification(withID: alarmID!)
                                 }
@@ -145,11 +146,11 @@ struct TodoItemView: View {
                                     // Notification 알람 생성 및 id Todo에 저장하기
                                     let id = manager.makeTodoNotification(year: year, month: month, day: day, hour: hour, minute: minute)
                                     
-                                    let todoData = Todo(folder: chosenFolder, id: todo.id, images: todo.images, createdAt: todo.createdAt, options: Options(alarm: contentAlarm, alarmUUID: id, memo: memo), isDone: todo.isDone)
+                                    let todoData = Todo(folder: chosenFolder, id: todo.id, images: cameraVM.photoData, createdAt: todo.createdAt, options: Options(alarm: contentAlarm, alarmUUID: id, memo: memo), isDone: todo.isDone)
                                     modelContext.insert(todoData)
                                     print("알람 데이터 있음")
                                 } else {
-                                    let todoData = Todo(folder: chosenFolder, id: todo.id, images: todo.images, createdAt: todo.createdAt, options: Options(memo: memo), isDone: todo.isDone)
+                                    let todoData = Todo(folder: chosenFolder, id: todo.id, images: cameraVM.photoData, createdAt: todo.createdAt, options: Options(memo: memo), isDone: todo.isDone)
                                     modelContext.insert(todoData)
                                     print("알람 데이터 없음")
                                 }
@@ -177,6 +178,7 @@ struct TodoItemView: View {
             }
             memo = todo.options.memo ?? ""
             alarmID = todo.options.alarmUUID ?? ""
+            cameraVM.photoData = todo.images
         })
     }
 }

--- a/PhotoTodo/TodoItemView.swift
+++ b/PhotoTodo/TodoItemView.swift
@@ -160,8 +160,9 @@ struct TodoItemView: View {
                             
                         }
                         .padding()
-                        
-                        MakeTodoView(chosenFolder: $chosenFolder, startViewType: .edit, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
+                        ScrollView{
+                            MakeTodoView(cameraVM: cameraVM, chosenFolder: $chosenFolder, startViewType: .edit, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
+                        }
                     }
                 }
                     


### PR DESCRIPTION
## 추가된 기능
MakeTodoView의 하단 ToolBar가 추가되었습니다.(이로써 MakeTodoView는 상단 툴바와 하단 툴바 모두 있는 뷰가 되었습니다.)  '이미지를 앨범에서 가져와 추가하는 기능'과 '이미지를 카메라로 찍어하는 기능' 중 전자를 먼저 구현하였습니다. 

## 변경사항
하단 Toolbar 코드가 추가되었습니다. 

```Swift
        .toolbar(.visible, for: .bottomBar)
        .toolbar{
            ToolbarItemGroup(placement: .bottomBar) {
                //TODO: 업로드 창에서 선택 후 이미지 넣기
                Button {
                    showingImagePicker = true
                } label : {
                    Image(systemName: "photo.on.rectangle")
                }
                NavigationLink {
//                        CameraView()
                }label: {
                    Image(systemName: "camera")
                }
            }
        }
```
photosUI의 sheet가 추가되었습니다. 이와 관련하여 사용되는 상태들 `showingImagePicker`, `selectedItems`이 추가되었습니다.

## 시연영상
https://github.com/user-attachments/assets/44c7984c-ccbf-4ae5-8efe-57332bec5cfb


