### PR TITLE
Fix: [feature/TodoItemView] onAppear상에 불필요한 로직으로 인한 성능저하 제거

### DIFF
--- a/PhotoTodo/TodoItemView.swift
+++ b/PhotoTodo/TodoItemView.swift
@@ -156,7 +156,6 @@ struct TodoItemView: View {
             }
             memo = todo.options.memo ?? ""
             alarmID = todo.options.alarmUUID ?? ""
-            cameraVM.photoData = todo.images
         })
     }
     


### PR DESCRIPTION
## 트러블 슈팅
스크롤을 움직일 때 화면이 심각하게 버벅거리는 현상이 있었습니다.

https://github.com/user-attachments/assets/9f242c56-5bd8-4a31-8947-b678de3e40f0


## 원인
매 `TodoItemView`이 노출될 때마다 `onAppear`상에서 `cameraVM.photodata`를 계속해서 바꾸는 로직이 문제가 되었습니다.

## 해결
`TodoItemView` 상에서는 `cameraVM`을 직접적으로 사용할 필요가 없기 때문에 이 코드를 제거하였습니다.

## 시연영상
https://github.com/user-attachments/assets/40f2de6c-6633-4362-8cb1-94a05f9cc6b5


