### PR TITLE
Fix: [fix/FolderListView] 기본 설정 관리 방식 변경, 폴더 추가 시 나던 에러 해결

### DIFF
--- a/PhotoTodo/FolderListView.swift
+++ b/PhotoTodo/FolderListView.swift
@@ -25,21 +25,21 @@ struct FolderListView: View {
     @State var selectedColor: Color?
     private var basicViewType: TodoGridViewType = .singleFolder
     private var doneListViewType: TodoGridViewType = .doneList
-    
+    @AppStorage("defaultFolderID") private var defaultFolderID: String?
     
     
     var body: some View {
             List {
                 //기본 폴더(인덱스 0에 있음) → 삭제 불가능하게 만들기 위해 따로 뺌
                 NavigationLink{
-                    TodoGridView(currentFolder: folders.count > 0 ? folders[0] : nil, viewType: basicViewType)
+                    TodoGridView(currentFolder: folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil, viewType: basicViewType)
                 } label : {
-                    FolderRow(folder: folders.count > 0 ? folders[0] : nil, viewType: basicViewType)
+                    FolderRow(folder: folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil, viewType: basicViewType)
                 }
 
                 
                 //기본 폴더를 제외하고는 모두 삭제 가능
-                ForEach(folders.dropFirst()) { folder in
+                ForEach(folders.filter({$0.id.uuidString != defaultFolderID})) { folder in
                     NavigationLink {
                         TodoGridView(currentFolder: folder, viewType: basicViewType)
                     } label: {
@@ -54,6 +54,12 @@ struct FolderListView: View {
                 } label : {
                     FolderRow(folder: nil, viewType: doneListViewType)
                 }
+            }
+            .onAppear {
+                if defaultFolderID != nil {
+                    return
+                }
+                defaultFolderID = folders.first(where: {$0.name == "기본"})?.id.uuidString
             }
 
             .scrollContentBackground(.hidden)


### PR DESCRIPTION
## 관련 이슈
- #60 
## 작업 내용
기본 폴더의 uuid로 폴더를 필터링하여, 기존의 인덱스 접근 방식으로 인해 발생하던 폴더 관리 오류가 더 이상 발생하지 않게 만들었습니다.