### PR TITLE
Fix: [fix/TodoItemView] 속성 수정 시 아이디 중복값으로 인해 발생하던 버그 수정

### DIFF
--- a/PhotoTodo/TodoItemView.swift
+++ b/PhotoTodo/TodoItemView.swift
@@ -178,11 +178,18 @@ struct TodoItemView: View {
                 let id = manager.makeTodoNotification(year: year, month: month, day: day, hour: hour, minute: minute)
                 
                 let todoData = Todo(folder: chosenFolder, id: todo.id, images: cameraVM.photoData, createdAt: todo.createdAt, options: Options(alarm: contentAlarm, alarmUUID: id, memo: memo), isDone: todo.isDone)
-                modelContext.insert(todoData)
+                DispatchQueue.main.async{
+                        modelContext.delete(todo)
+                        modelContext.insert(todoData)
+                }
+                
                 print("알람 데이터 있음")
             } else {
                 let todoData = Todo(folder: chosenFolder, id: todo.id, images: cameraVM.photoData, createdAt: todo.createdAt, options: Options(memo: memo), isDone: todo.isDone)
-                modelContext.insert(todoData)
+                DispatchQueue.main.async{
+                        modelContext.delete(todo)
+                        modelContext.insert(todoData)
+                }
                 print("알람 데이터 없음")
             }
             editTodoisActive.toggle()


### PR DESCRIPTION
## 관련 이슈
- #61 

## 수정 사항
속성 업데이트 시 중복된 아이디로 인해 발생하던 오류가 있었는데, 에딧 화면에서 완료 버튼을 누를 때 기존의 투두 아이템을 삭제하고 기존의 정보를 복사하고 업데이트 사항을 반영한 새로운 아이템을 삽입하도록 변경하여 버그를 해결하였습니다.
