### PR TITLE
투두 아이템 뷰 리팩토링

### DIFF
--- a/PhotoTodo/TodoItemView.swift
+++ b/PhotoTodo/TodoItemView.swift
@@ -126,6 +126,9 @@ struct TodoItemView: View {
                                 .padding(4)
                         }
                         .disabled(editMode == .active)
+                        .sensoryFeedback(.success, trigger: todo.isDone) { oldValue, newValue in
+                            return todo.isDone == true
+                        }
                     }
                 
             }


### PR DESCRIPTION
## 관련 이슈
- #61 
- #67 

## 작업 내용 1
투두 아이템을 수정하는 로직을 수정하였습니다.
기존 방식 : 새로운 투두아이템을 인서트하고 기존의 투두아이템을 삭제
수정된 방식 : 기존의 투두 아이템의 속성을 바로 변경
이 방법이 스위프트 데이터를 수정하는 일반적인 방법인 듯 합니다.
https://velog.io/@soc06212/SwiftUI-마음으로-이해하는-SwiftData

## 작업 내용 2
투두 아이템을 완료 표시할 때 햅틱 피드백이 적용되도록 변경하였습니다.

관련 코드
```Swift
.sensoryFeedback(.success, trigger: todo.isDone) { oldValue, newValue in
    return todo.isDone == true
}
```
