### PR TITLE
Fix: [fix/TodoItemView] 탭바 가운데 정렬 및 Figma 디자인 파일과 일치 작업

### DIFF
--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -31,71 +31,87 @@ struct TabBarView: View {
     
     var body: some View {
         NavigationStack/*(path: $path)*/ {
-            ZStack{
-                Color("gray/gray-200").ignoresSafeArea()
-                VStack{
+            ZStack(alignment: .bottom) {
+                Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
+                VStack(spacing: 0) {
                     if page == .main {
                         MainView()
                     } else if page == .folder {
                         FolderListView()
                     }
                     
-                    HStack {
-                        Spacer()
-                        Button {
-                            page = .main
-                        } label: {
-                            VStack{
-                                Image(page == .main ? "allTodo.fill" : "allTodo")
-                                    .resizable()
-                                    .frame(width: 20, height: 20)
-                                Text("전체투두")
-                                    .font(.system(size: 12))
-                                    .padding(.top, 2)
-                                    .bold()
+                    HStack(spacing: 0) {
+                        HStack {
+                            Button {
+                                page = .main
+                            } label: {
+                                VStack(spacing: 0) {
+                                    VStack{
+                                        Image(page == .main ? "allTodo.fill" : "allTodo")
+                                            .font(.system(size: 24))
+                                            .aspectRatio(contentMode: .fit)
+                                            .frame(width: 20, height: 20)
+                                    }
+                                    .frame(width: 44, height: 44)
+                                    Text("전체투두")
+                                        .font(.system(size: 12))
+                                        .bold()
+                                }
+                                .frame(height: 60)
                             }
+                            .foregroundStyle(page == .main ? Color("gray/gray-700") : Color("gray/gray-500"))
+                            
+                            Spacer()
+                            
+                            Button {
+                                page = .folder
+                            } label: {
+                                VStack(spacing: 0) {
+                                    VStack {
+                                        Image(systemName: page == .folder ? "folder.fill" : "folder")
+                                            .font(.system(size: 24))
+                                            .aspectRatio(contentMode: .fit)
+                                    }
+                                    .frame(width: 44, height: 44)
+                                    Text("폴더")
+                                        .font(.system(size: 12))
+                                        .bold()
+                                }
+                                .frame(height: 60)
+                            }
+                            .foregroundStyle(page == .folder ? Color("gray/gray-700") : Color("gray/gray-500"))
                         }
-                        .foregroundStyle(page == .main ? Color("gray/gray-700") : Color("gray/gray-500"))
-                        
-                        
-                        NavigationLink  {
-                            CameraView(isCameraSheetOn: $isCameraSheetOn)
-                        } label:  {
-                            ZStack{
-                                Circle()
-                                    .frame(width: 70, height: 70)
-                                    .foregroundStyle(Color.white)
-                                    .shadow(color: .lightGray, radius: 10)
-                                
+                        .padding(.horizontal, 42)
+                        .padding(.bottom, 23)
+                    }
+                    .background(Color.white)
+                }
+                
+                HStack {
+                    NavigationLink  {
+                        CameraView(isCameraSheetOn: $isCameraSheetOn)
+                    } label:  {
+                        ZStack{
+                            Circle()
+                                .frame(width: 78, height: 78)
+                                .foregroundStyle(Color.white)
+                                .shadow(color: .lightGray, radius: 10)
+                            VStack {
                                 Image("cloverCamera.fill")
-                                    .resizable()
-                                    .frame(width: 40, height: 30)
-                                    .foregroundStyle(Color.green)
+                                    .font(.system(size: 40))
+                                    .aspectRatio(contentMode: .fill)
+                                    .foregroundStyle(Color("green/green-400"))
                             }
+                            .frame(width: 48, height: 48)
                         }
-                        //                        .navigationDestination(for: String.self) { value in
-                        //                            CameraView()
-                        //                        }
-                        .padding(.horizontal, 55)
-                        
-                        Button {
-                            page = .folder
-                        } label: {
-                            VStack{
-                                Image(systemName: page == .folder ? "folder.fill" : "folder")
-                                    .resizable()
-                                    .frame(width: 25, height: 20)
-                                Text("폴더")
-                                    .font(.system(size: 12))
-                                    .padding(.top, 2)
-                                    .bold()
-                            }
-                        }
-                        .foregroundStyle(page == .folder ? Color("gray/gray-700") : Color("gray/gray-500"))
-                        Spacer()
-                    }.background(Color(.white))
+                    }
+                    //                        .navigationDestination(for: String.self) { value in
+                    //                            CameraView()
+                    //                        }
+                    .offset(y: -42)
                 }
             }
+            .edgesIgnoringSafeArea(.bottom)
             .ignoresSafeArea(.keyboard)
         }
         .fullScreenCover(isPresented: $isOnboarindViewActive) {


### PR DESCRIPTION
[진행사항 공유]
- 기존에 탭바 중앙 버튼이 정 가운데에 위치하지 않은 문제 해결
- 아이폰 기종에 상관 없이 탭바 내부 버튼 및 이미지 전부 AutoFramework로 자동 조절되도록 개선

[실행영상]
<img width="323" alt="스크린샷 2025-01-02 오후 10 02 48" src="https://github.com/user-attachments/assets/0ae55633-5362-40ba-a7e2-e3a697528fe2" />


[SE3 버전]
<img width="323" alt="스크린샷 2025-01-02 오후 10 02 48" src="https://github.com/user-attachments/assets/19a38671-fd21-4841-a156-705b7cc51825" />


[기타]
- font-extension의 부재로 추후 font 관련 설정 추가 이후 조절 필요
- custom camera 이미지의 경우 추후 디자이너와 작업 시 크기 확인이 필요할 듯 함

[아이폰 15Pro 기준, 피그마 디자인과 겹쳐서 위치상 문제 없음 확임]
<img width="323" alt="스크린샷 2025-01-02 오후 10 11 01" src="https://github.com/user-attachments/assets/5ad2db1d-aa9e-4e0f-bac4-3aab86a8bacd" />
