### PR TITLE
Fix: Folder 삭제 오류 수정

### DIFF
--- a/PhotoTodo/FolderListView.swift
+++ b/PhotoTodo/FolderListView.swift
@@ -51,6 +51,10 @@ struct FolderListView: View {
                         }
                     })
                 }
+                .onDelete { _ in
+                    // editMode일 때 UI가 반응하도록 하기 위해 빈 클로저를 남겼습니다.
+                    // 실제 삭제 실행시에는 swipeActions으로 넘겨받은 클로저가 호출됩니다.
+                }
                 //TODO: 옵션을 줘서 완료된 것(되지 않은 것)만 필터링해서 보여주기
                 //리스트 뷰의 마지막에는 완료함이 위치함
                 NavigationLink {
@@ -70,7 +74,6 @@ struct FolderListView: View {
             //            .background(Color.white.edgesIgnoringSafeArea(.all))
             .navigationBarTitle("폴더")
             .toolbar {
-
                 ToolbarItem {
                     if editMode == .inactive {
                         Button(action: toggleShowingSheet) {
@@ -104,14 +107,6 @@ struct FolderListView: View {
                 todos: []
             )
             modelContext.insert(newFolder)
-        }
-    }
-    
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            for index in offsets {
-                modelContext.delete(folders[index+1])
-            }
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #83 

## 수정 사항
기존 로직은 클로저 바깥에서 index를 통해 folder에 접근하여 삭제하는데, 말씀해주신 부분처럼 뷰에서 보여지는 순서와 데이터의 순서의 일치가 보장되지 않아 이런 접근은 문제가 있었습니다. 수정된 로직에서는 매개변수로 folder 자체를 가진 클로저 내부에서 삭제가 이루어지도록 접근하였고, 불일치의 문제를 피할 수 있었습니다. 

## 시연 영상
삭제하는 부분은 20초 이후에서 확인할 수 있습니다. 
https://github.com/user-attachments/assets/ac86d1ba-9b56-4529-9b2d-4a8ba7ffd58a

## 참고 자료
제가 참고한 자료입니다!
https://www.hackingwithswift.com/quick-start/swiftdata/how-to-delete-a-swiftdata-object

## 요청
QA 함께 해주시면 더 좋을 것 같아요.