### PR TITLE
메모리 누수 관련 미사용 코드 삭제

### DIFF
--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -35,7 +35,6 @@ struct MakeTodoView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
     @State private var cameraVM = CameraViewModel.shared
-    @State private var cameraManager = CameraManager()
     @Binding var chosenFolder: Folder?
     var startViewType: startViewType
     


### PR DESCRIPTION
## 관련 이슈
- #105 

## 변경 사항
위 이슈에서 보고했듯 프로파일러로 확인했을 때 `MakeTodoView` 를 열고 닫을 때마다 메모리 누수가 발생하는 것을 확인하였는데요, 원인을 분석해 보니 `CameraManager` 내부의 카메라와 관련된 메모리가 잘 해제가 안되는 것을 확인하였습니다. GPT에 따르면, 메모리 누수인 것처럼 보여도 실제로 메모리 누수가 아닐 수도 있다는 식으로 말해주기도 하는데, 우선 `MakeTodoView`에서 `CameraManager`가 사용되고 있는 부분은 없어서 삭제 처리하였고, `MakeTodoView`를 열고 닫을 때 나오던 명시적 메모리 누수는 더이상 감지되지 않는 것을 확인하였습니다. 그런데 카메라와 관련된 뷰(`CameraView` 등)를 열고 닫을 때는 명시적으로는 메모리 누수가 감지되고 있어서, 추가적인 확인이 필요할수도 있을 것 같습니다. 