### PR TITLE
메인 뷰 및 그리드 뷰 UI 반응속도 개선 및 탭바 네비게이션 방식 변경

### DIFF
--- a/PhotoTodo/CameraView.swift
+++ b/PhotoTodo/CameraView.swift
@@ -134,12 +134,22 @@ struct CameraView: View {
             }
             // true일 때는 photoData를 그대로 보존함
             // 네비게이션 되돌아가는 로직
+            // onAppear 시 home이 true일 때는 메인 화면으로 바로 돌아감
             if home == nil { return }
             if home! == false { return }
             dismiss()
         })
+        
         .task(id: cameraCaptureisActive) {
+            // onAppear 이후에 수행됨
+            // onAppear 시 home이 false여서 메인화면으로 바로 돌아가지 않더라도,
+            // 카메라 뷰에서 '뒤로'버튼을 눌렀을 때 home이 참값을 가지고 있어야, 탭바가 원래되로 돌아오기 때문에 다시 home을 참값으로 바꿔주는 작업이 필요함
             if !cameraCaptureisActive {
+                // 카메라를 촬영해서(cameraCaptureisActive가 true임) makeTodoView로 들어가는 경우,
+                // button 내부의 액션 클로저에서 home값을 false로 다시 바꿔놓는데,
+                // task는 makeTodoView로 들어간 이후에 실행되므로,
+                // home을 true로 다시 바꿔놓으면 뒤로가기 했을 때 위의 onAppear에 의해 메인으로 바로 돌아가게 됨
+                // 이런 이유로 카메라를 촬영해서 들어가는 경우에는 이 처리를 수행하지 않도록 해둠
                 home = true
             }
         }

--- a/PhotoTodo/CameraView.swift
+++ b/PhotoTodo/CameraView.swift
@@ -126,6 +126,7 @@ struct CameraView: View {
             .padding(.bottom, 10)
             .padding(.top, 30)
         }
+
         .navigationBarTitleDisplayMode(.inline)
         .onAppear(perform: {
             if isCameraSheetOn == false {

--- a/PhotoTodo/CameraView.swift
+++ b/PhotoTodo/CameraView.swift
@@ -30,11 +30,11 @@ struct CameraView: View {
     // 폴더 관련
     @State var chosenFolder: Folder? = nil
     @Query private var folders: [Folder]
-    @State private var home: Bool? = false
     @State private var lastScale: CGFloat = 1.0
     
     //이미지 추가 관련
     @Binding var isCameraSheetOn: Bool
+    @Binding var home: Bool?
     
     var body: some View {
         VStack(alignment: .center, spacing: 0){
@@ -58,6 +58,7 @@ struct CameraView: View {
                                     cameraManager.takePhoto()
                                     cameraCaptureisActive.toggle()
                                     isCameraSheetOn = false
+                                    home = false
                                 } label: {
                                     ZStack{
                                         Circle().frame(width: 78, height: 78)
@@ -134,9 +135,13 @@ struct CameraView: View {
             // 네비게이션 되돌아가는 로직
             if home == nil { return }
             if home! == false { return }
-            home = false
             dismiss()
-        })        
+        })
+        .task(id: cameraCaptureisActive) {
+            if !cameraCaptureisActive {
+                home = true
+            }
+        }
     }
     
     private var cameraPreview: some View {
@@ -168,5 +173,6 @@ struct CameraView: View {
 
 #Preview {
     @Previewable @State var isCameraSheetOn = false
-    CameraView(isCameraSheetOn: $isCameraSheetOn)
+    @Previewable @State var home: Bool? = false
+    CameraView(isCameraSheetOn: $isCameraSheetOn, home: $home)
 }

--- a/PhotoTodo/FolderCarouselView.swift
+++ b/PhotoTodo/FolderCarouselView.swift
@@ -90,12 +90,6 @@ struct FolderCarouselView: View {
                                     )
                                     .clipShape(RoundedRectangle(cornerRadius: 5))
                             }
-                            .onAppear(perform: {
-                                withAnimation {
-                                    selectedButtonIndex = 0
-                                    proxy.scrollTo(0, anchor: .center)
-                                }
-                            })
                             .id(index)
                         }
                         
@@ -112,6 +106,20 @@ struct FolderCarouselView: View {
                         })
                         
                     }
+                    .onAppear(perform: {
+                        withAnimation {
+                            selectedButtonIndex = 0
+                            if let chosenFolder = chosenFolder {
+                                for (index, folder) in orderedFolder.enumerated() {
+                                    if folder == chosenFolder {
+                                        selectedButtonIndex = index
+                                        break
+                                    }
+                                }
+                            }
+                            proxy.scrollTo(selectedButtonIndex, anchor: .center)
+                        }
+                    })
                     .frame(minWidth: geometry.size.width)
                     .padding(.horizontal, (geometry.size.width / 2) - 41)
                 }

--- a/PhotoTodo/FolderListView.swift
+++ b/PhotoTodo/FolderListView.swift
@@ -20,7 +20,7 @@ struct FolderListView: View {
     @Environment(\.modelContext) var modelContext
     @State private var editMode: EditMode = .inactive
     @Query var folders: [Folder]
-    @Binding var recentlyVisitedFolder: Folder?
+    @Binding var recentlySeenFolder: Folder?
     
     //폴더 삭제시
     @State private var showingAlert = false
@@ -45,11 +45,10 @@ struct FolderListView: View {
         return folderManager.getOrderedFolder(folders, folderOrders)
     }
     
-    // Custom initializer
-    init(recentFolder: Binding<Folder?>) {
-        self._recentlyVisitedFolder = recentFolder
+    
+    init(recentlySeenFolder: Binding<Folder?>) {
+        self._recentlySeenFolder = recentlySeenFolder
     }
-
     
     var body: some View {
         List {
@@ -57,7 +56,7 @@ struct FolderListView: View {
             NavigationLink{
                 TodoGridView(currentFolder: folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil, viewType: basicViewType)
                     .onAppear {
-                        recentlyVisitedFolder = folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil
+                        recentlySeenFolder = folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil
                     }
             } label : {
                 FolderRow(folder: folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil, viewType: basicViewType)
@@ -76,7 +75,7 @@ struct FolderListView: View {
                             NavigationLink {
                                 TodoGridView(currentFolder: folder, viewType: basicViewType)
                                     .onAppear {
-                                        recentlyVisitedFolder = folder
+                                        recentlySeenFolder = folder
                                     }
                             } label: {
                                 FolderRow(folder: folder, viewType: basicViewType)
@@ -94,7 +93,7 @@ struct FolderListView: View {
             NavigationLink {
                 DoneListView()
                                 .onAppear {
-                                    recentlyVisitedFolder = folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil
+                                    recentlySeenFolder = folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil
                                 }
             } label : {
                 FolderRow(folder: nil, viewType: doneListViewType)
@@ -110,7 +109,7 @@ struct FolderListView: View {
             //folderOrder 세팅 로직
             folderManager.setFolderOrder(folders, folderOrders, modelContext)
             
-            recentlyVisitedFolder = nil
+            recentlySeenFolder = nil
         }
         
         .scrollContentBackground(.hidden)
@@ -307,9 +306,9 @@ extension FolderRow {
 
 
 #Preview {
-    @Previewable @State var recentFolder: Folder? = nil
+    @Previewable @State var recentlySeenFolder: Folder? = nil
     
-    FolderListView(recentFolder: $recentFolder)
+    FolderListView(recentlySeenFolder: $recentlySeenFolder)
         .modelContainer(for: Folder.self, inMemory: true)
 }
 

--- a/PhotoTodo/FolderListView.swift
+++ b/PhotoTodo/FolderListView.swift
@@ -185,7 +185,7 @@ private struct FolderRow: View {
     @Environment(\.editMode) private var editMode
     @State var folder: Folder?
     @State var viewType: TodoGridViewType
-    @Query private var todos: [Todo]
+    @Query private var folders: [Folder]
     @State private var doneCount: Int = 0 // 뷰가 업데이트될 때마다 다시 계산하는 대신, 값을 미리 계산하여 사용
     @State private var incompleteTodosCount: Int = 0
     
@@ -207,7 +207,10 @@ private struct FolderRow: View {
     @AppStorage("defaultFolderID") private var defaultFolderID: String?
     @State private var showingAlert = false
     @Query var folderOrders: [FolderOrder]
-
+    
+    private var todos: [Todo] {
+        folders.flatMap { $0.todos }
+    }
     
     var body: some View {
         HStack{

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -365,6 +365,7 @@ struct MakeTodoView: View {
                 Button {
                     if cameraVM.photoData.count < 10 {
                         isCameraSheetOn = true
+                        home = false
                     } else {
                         //TODO: 토스트 메세지 출력하기
                         print("이미지는 10장 이상 추가할 수 없습니다.")

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -337,7 +337,7 @@ struct MakeTodoView: View {
         }
         .sheet(isPresented: $isCameraSheetOn, content: {
             NavigationStack{
-                CameraView(isCameraSheetOn: $isCameraSheetOn)
+                CameraView(isCameraSheetOn: $isCameraSheetOn, home: $home)
             }
             .presentationDragIndicator(.visible)
         })
@@ -475,7 +475,7 @@ extension Binding {
     @Previewable @State var contentAlarm = Date()
     @Previewable @State var memo: String = ""
     @Previewable @State var alarmDataisEmpty: Bool = true
-    @Previewable @State var home: Bool = false
+    @Previewable @State var home: Bool? = false
     @Previewable @State var alarmID = ""
     return MakeTodoView(chosenFolder: $chosenFolder, startViewType: .camera, contentAlarm: .constant(Date()), alarmID: .constant(""), alarmDataisEmpty: .constant(true), memo: .constant(""), home: .constant(true))
     

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -343,6 +343,13 @@ struct MakeTodoView: View {
         })
         .photosPicker(isPresented: $showingImagePicker, selection: $selectedItems,  maxSelectionCount: 10-cameraVM.photoData.count, matching: .not(.videos))
         .onChange(of: selectedItems, loadImage)
+        .onChange(of: isCameraSheetOn) {
+            // 이 작업이 없으면 MakeTodoView에서 시트로 카메라를 열었을 때 '뒤로' 버튼을 누르면 네비게이션 오류가 남
+            // 카메라를 열고 나서 사진을 찍지 않으면, home이 참인 상태로 남아있게 됨 (사진을 찍을 때 다시 home을 false로 바꿔주는 로직이 있음)
+            // home이 참인 상태로 뒤돌아가면, task보다 먼저 실행되는 onAppear에 의해 메인 화면으로 다시 돌아감
+            // 이러한 이유로, 원치 않은 사이드 이팩트를 막기 위해 카메라 시트를 닫을 때에 반드시 home을 false로 바꿔줘야 함
+            home = false
+        }
         .toolbar(startViewType == .edit ? .hidden : .visible)
         .toolbar(content: {
             // 완료 및 저장 버튼

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -32,6 +32,9 @@ struct TabBarView: View {
     @AppStorage("onboarding") var isOnboarindViewActive: Bool = true
     @AppStorage("deletionCount") var deletionCount: Int = 0
     
+    @State var recentlySeenFolder: Folder? = nil
+    @AppStorage("defaultFolderID") private var defaultFolderID: String?
+    
     var folderManager = FolderManager()
     @State var recentTag: Int = 0
     
@@ -53,7 +56,7 @@ struct TabBarView: View {
                                     }
                                     .animation(.easeInOut, value: isCameraViewActive)
                                     .navigationDestination(isPresented: $isCameraViewNavigate){
-                                            CameraView(isCameraSheetOn: $isCameraSheetOn, home: $home)
+                                        CameraView(chosenFolder: recentlySeenFolder, isCameraSheetOn: $isCameraSheetOn, home: $home)
                                             .onDisappear {
                                                 if home == true {
                                                     isCameraViewActive = false
@@ -68,7 +71,7 @@ struct TabBarView: View {
                                 NavigationStack {
                                     ZStack{
                                         Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
-                                        FolderListView()
+                                        FolderListView(recentFolder: $recentlySeenFolder)
                                     }
                                 }
                                 .tag(2)
@@ -88,6 +91,7 @@ struct TabBarView: View {
                                 Button {
                                     selectedTab = 0
                                     recentTag = 0
+                                    recentlySeenFolder = folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil
                                     page = .main
                                 } label: {
                                     VStack(spacing: 0) {
@@ -112,6 +116,7 @@ struct TabBarView: View {
                                     selectedTab = 2
                                     recentTag = 2
                                     page = .folder
+                                    recentlySeenFolder = folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil
                                 } label: {
                                     VStack(spacing: 0) {
                                         VStack {

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -33,19 +33,38 @@ struct TabBarView: View {
     var folderManager = FolderManager()
     
     var body: some View {
-        NavigationStack/*(path: $path)*/ {
+        
             ZStack(alignment: .bottom) {
-                Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
-                VStack(spacing: 0) {
-                    if page == .main {
-                        MainView()
-                    } else if page == .folder {
-                        FolderListView()
+                
+                TabView(selection: $selectedTab) {
+                    NavigationStack {
+                        ZStack{
+                            Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
+                            MainView()
+                        }
                     }
+                    .tag(0)
                     
+                    CameraView(isCameraSheetOn: $isCameraSheetOn)
+                        .tag(1)
+                    
+                    NavigationStack {
+                        ZStack{
+                            Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
+                            FolderListView()
+                        }
+                    }
+                    .tag(2)
+                }
+                .onAppear {
+                    UITabBar.appearance().isHidden = true
+                }
+                VStack(spacing: 0) {
+                    Spacer()
                     HStack(spacing: 0) {
                         HStack {
                             Button {
+                                selectedTab = 0
                                 page = .main
                             } label: {
                                 VStack(spacing: 0) {
@@ -67,6 +86,7 @@ struct TabBarView: View {
                             Spacer()
                             
                             Button {
+                                selectedTab = 2
                                 page = .folder
                             } label: {
                                 VStack(spacing: 0) {
@@ -92,6 +112,7 @@ struct TabBarView: View {
                 
                 HStack {
                     NavigationLink  {
+//                        selectedTab = 1
                         CameraView(isCameraSheetOn: $isCameraSheetOn)
                     } label:  {
                         ZStack{
@@ -116,7 +137,7 @@ struct TabBarView: View {
             }
             .edgesIgnoringSafeArea(.bottom)
             .ignoresSafeArea(.keyboard)
-        }
+        
         .fullScreenCover(isPresented: $isOnboarindViewActive) {
             OnboardingView()
         }

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -15,7 +15,9 @@ enum page {
 struct TabBarView: View {
     @State private var selectedTab = 0
     @State private var isCameraViewActive = false
-    //    @State private var path: NavigationPath = NavigationPath()
+    @State private var isCameraViewNavigate = false
+    @State private var home: Bool? = false
+    
     @State private var page: page = .main
     @AppStorage("hasBeenLaunched") private var hasBeenLaunched = false
     @Environment(\.modelContext) private var modelContext
@@ -33,108 +35,133 @@ struct TabBarView: View {
     var folderManager = FolderManager()
     
     var body: some View {
-        
-            ZStack(alignment: .bottom) {
-                
-                TabView(selection: $selectedTab) {
-                    NavigationStack {
-                        ZStack{
-                            Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
-                            MainView()
-                        }
-                    }
-                    .tag(0)
-                    
-                    CameraView(isCameraSheetOn: $isCameraSheetOn)
-                        .tag(1)
-                    
-                    NavigationStack {
-                        ZStack{
-                            Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
-                            FolderListView()
-                        }
-                    }
-                    .tag(2)
-                }
-                .onAppear {
-                    UITabBar.appearance().isHidden = true
-                }
-                VStack(spacing: 0) {
-                    Spacer()
-                    HStack(spacing: 0) {
-                        HStack {
-                            Button {
-                                selectedTab = 0
-                                page = .main
-                            } label: {
-                                VStack(spacing: 0) {
-                                    VStack{
-                                        Image(page == .main ? "allTodo.fill" : "allTodo")
-                                            .font(.system(size: 24))
-                                            .aspectRatio(contentMode: .fit)
-                                            .frame(width: 20, height: 20)
-                                    }
-                                    .frame(width: 44, height: 44)
-                                    Text("전체투두")
-                                        .font(.system(size: 12))
-                                        .bold()
+                ZStack(alignment: .bottom) {
+                    VStack{
+                        if isCameraViewActive {
+                            NavigationStack {
+                                VStack {
+                                    EmptyView()
                                 }
-                                .frame(height: 60)
-                            }
-                            .foregroundStyle(page == .main ? Color("gray/gray-700") : Color("gray/gray-500"))
-                            
-                            Spacer()
-                            
-                            Button {
-                                selectedTab = 2
-                                page = .folder
-                            } label: {
-                                VStack(spacing: 0) {
-                                    VStack {
-                                        Image(systemName: page == .folder ? "folder.fill" : "folder")
-                                            .font(.system(size: 24))
-                                            .aspectRatio(contentMode: .fit)
+                                .animation(.easeInOut, value: isCameraViewActive)
+                                .navigationDestination(isPresented: $isCameraViewNavigate){
+                                        CameraView(isCameraSheetOn: $isCameraSheetOn, home: $home)
+                                        .onDisappear {
+                                            if home == true {
+                                                isCameraViewActive = false
+                                                home = false
+                                            }
+                                        }
                                     }
-                                    .frame(width: 44, height: 44)
-                                    Text("폴더")
-                                        .font(.system(size: 12))
-                                        .bold()
+                            }
+                        } else {
+                            TabView(selection: $selectedTab) {
+                                NavigationStack {
+                                    ZStack{
+                                        Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
+                                        MainView()
+                                    }
                                 }
-                                .frame(height: 60)
+                                .tag(0)
+                                
+                                CameraView(isCameraSheetOn: $isCameraSheetOn, home: $home)
+                                    .tag(1)
+                                
+                                NavigationStack {
+                                    ZStack{
+                                        Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
+                                        FolderListView()
+                                    }
+                                }
+                                .tag(2)
                             }
-                            .foregroundStyle(page == .folder ? Color("gray/gray-700") : Color("gray/gray-500"))
-                        }
-                        .padding(.horizontal, 42)
-                        .padding(.bottom, 23)
-                    }
-                    .background(Color.white)
-                }
-                
-                HStack {
-                    NavigationLink  {
-//                        selectedTab = 1
-                        CameraView(isCameraSheetOn: $isCameraSheetOn)
-                    } label:  {
-                        ZStack{
-                            Circle()
-                                .frame(width: 78, height: 78)
-                                .foregroundStyle(Color.white)
-                                .shadow(color: .lightGray, radius: 10)
-                            VStack {
-                                Image("cloverCamera.fill")
-                                    .font(.system(size: 40))
-                                    .aspectRatio(contentMode: .fill)
-                                    .foregroundStyle(Color("green/green-400"))
+                            .onAppear {
+                                UITabBar.appearance().isHidden = true
                             }
-                            .frame(width: 48, height: 48)
                         }
+
                     }
-                    //                        .navigationDestination(for: String.self) { value in
-                    //                            CameraView()
-                    //                        }
-                    .offset(y: -42)
+                    .animation(.easeInOut, value: isCameraViewActive)
+
+                    VStack(spacing: 0) {
+                        Spacer()
+                        HStack(spacing: 0) {
+                            HStack {
+                                Button {
+                                    selectedTab = 0
+                                    page = .main
+                                } label: {
+                                    VStack(spacing: 0) {
+                                        VStack{
+                                            Image(page == .main ? "allTodo.fill" : "allTodo")
+                                                .font(.system(size: 24))
+                                                .aspectRatio(contentMode: .fit)
+                                                .frame(width: 20, height: 20)
+                                        }
+                                        .frame(width: 44, height: 44)
+                                        Text("전체투두")
+                                            .font(.system(size: 12))
+                                            .bold()
+                                    }
+                                    .frame(height: 60)
+                                }
+                                .foregroundStyle(page == .main ? Color("gray/gray-700") : Color("gray/gray-500"))
+                                
+                                Spacer()
+                                
+                                Button {
+                                    selectedTab = 2
+                                    page = .folder
+                                } label: {
+                                    VStack(spacing: 0) {
+                                        VStack {
+                                            Image(systemName: page == .folder ? "folder.fill" : "folder")
+                                                .font(.system(size: 24))
+                                                .aspectRatio(contentMode: .fit)
+                                        }
+                                        .frame(width: 44, height: 44)
+                                        Text("폴더")
+                                            .font(.system(size: 12))
+                                            .bold()
+                                    }
+                                    .frame(height: 60)
+                                }
+                                .foregroundStyle(page == .folder ? Color("gray/gray-700") : Color("gray/gray-500"))
+                            }
+                            .padding(.horizontal, 42)
+                            .padding(.bottom, 23)
+                        }
+                        .background(Color.white)
+                    }
+                    .animation(.easeInOut, value: isCameraViewActive)
+                    .opacity(isCameraViewActive ? 0 : 1)
+                    
+                    HStack {
+                        Button  {
+                            isCameraViewActive = true
+                            DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+                                isCameraViewNavigate = true
+                            }
+                        } label:  {
+                            ZStack{
+                                Circle()
+                                    .frame(width: 78, height: 78)
+                                    .foregroundStyle(Color.white)
+                                    .shadow(color: .lightGray, radius: 10)
+                                VStack {
+                                    Image("cloverCamera.fill")
+                                        .font(.system(size: 40))
+                                        .aspectRatio(contentMode: .fill)
+                                        .foregroundStyle(Color("green/green-400"))
+                                }
+                                .frame(width: 48, height: 48)
+                            }
+                        }
+                        .offset(y: -42)
+                    }
+                    .opacity(isCameraViewActive ? 0 : 1)
+                    .animation(.easeInOut, value: isCameraViewActive)
                 }
-            }
+
             .edgesIgnoringSafeArea(.bottom)
             .ignoresSafeArea(.keyboard)
         

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -112,7 +112,7 @@ struct TabBarView: View {
                         
                         Spacer()
                         
-                        Button { //카메라 탭
+                        Button { //폴더뷰 탭
                             selectedTab = 2
                             recentTag = 2
                             page = .folder
@@ -166,7 +166,6 @@ struct TabBarView: View {
                 .offset(y: -42)
             }
             .opacity(isCameraViewActive ? 0 : 1)
-            .animation(.easeInOut, value: isCameraViewActive)
         }
         
         .edgesIgnoringSafeArea(.bottom)

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -33,27 +33,11 @@ struct TabBarView: View {
     @AppStorage("deletionCount") var deletionCount: Int = 0
     
     var folderManager = FolderManager()
+    @State var recentTag: Int = 0
     
     var body: some View {
                 ZStack(alignment: .bottom) {
                     VStack{
-                        if isCameraViewActive {
-                            NavigationStack {
-                                VStack {
-                                    EmptyView()
-                                }
-                                .animation(.easeInOut, value: isCameraViewActive)
-                                .navigationDestination(isPresented: $isCameraViewNavigate){
-                                        CameraView(isCameraSheetOn: $isCameraSheetOn, home: $home)
-                                        .onDisappear {
-                                            if home == true {
-                                                isCameraViewActive = false
-                                                home = false
-                                            }
-                                        }
-                                    }
-                            }
-                        } else {
                             TabView(selection: $selectedTab) {
                                 NavigationStack {
                                     ZStack{
@@ -62,9 +46,24 @@ struct TabBarView: View {
                                     }
                                 }
                                 .tag(0)
-                                
-                                CameraView(isCameraSheetOn: $isCameraSheetOn, home: $home)
-                                    .tag(1)
+
+                                NavigationStack {
+                                    VStack {
+                                        EmptyView()
+                                    }
+                                    .animation(.easeInOut, value: isCameraViewActive)
+                                    .navigationDestination(isPresented: $isCameraViewNavigate){
+                                            CameraView(isCameraSheetOn: $isCameraSheetOn, home: $home)
+                                            .onDisappear {
+                                                if home == true {
+                                                    isCameraViewActive = false
+                                                    home = false
+                                                    selectedTab = recentTag
+                                                }
+                                            }
+                                        }
+                                }
+                                .tag(1)
                                 
                                 NavigationStack {
                                     ZStack{
@@ -77,7 +76,7 @@ struct TabBarView: View {
                             .onAppear {
                                 UITabBar.appearance().isHidden = true
                             }
-                        }
+
 
                     }
                     .animation(.easeInOut, value: isCameraViewActive)
@@ -88,6 +87,7 @@ struct TabBarView: View {
                             HStack {
                                 Button {
                                     selectedTab = 0
+                                    recentTag = 0
                                     page = .main
                                 } label: {
                                     VStack(spacing: 0) {
@@ -110,6 +110,7 @@ struct TabBarView: View {
                                 
                                 Button {
                                     selectedTab = 2
+                                    recentTag = 2
                                     page = .folder
                                 } label: {
                                     VStack(spacing: 0) {
@@ -137,6 +138,7 @@ struct TabBarView: View {
                     
                     HStack {
                         Button  {
+                            selectedTab = 1
                             isCameraViewActive = true
                             DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
                                 isCameraViewNavigate = true

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -57,13 +57,6 @@ struct TabBarView: View {
                         .animation(.easeInOut, value: isCameraViewActive)
                         .navigationDestination(isPresented: $isCameraViewNavigate){
                             CameraView(chosenFolder: recentlySeenFolder, isCameraSheetOn: $isCameraSheetOn, home: $home)
-                                .onDisappear {
-                                    if home == true {
-                                        isCameraViewActive = false
-                                        home = false
-                                        selectedTab = recentTag
-                                    }
-                                }
                         }
                     }
                     .tag(1)
@@ -75,6 +68,13 @@ struct TabBarView: View {
                         }
                     }
                     .tag(2)
+                }
+                .onChange(of: isCameraViewNavigate) { newValue in
+                    if newValue == false && home == true {
+                        isCameraViewActive = false
+                        home = false
+                        selectedTab = recentTag
+                    }
                 }
                 .onAppear {
                     UITabBar.appearance().isHidden = true

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -71,7 +71,7 @@ struct TabBarView: View {
                                 NavigationStack {
                                     ZStack{
                                         Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
-                                        FolderListView(recentFolder: $recentlySeenFolder)
+                                        FolderListView(recentlySeenFolder: $recentlySeenFolder)
                                     }
                                 }
                                 .tag(2)

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -39,138 +39,138 @@ struct TabBarView: View {
     @State var recentTag: Int = 0
     
     var body: some View {
-                ZStack(alignment: .bottom) {
-                    VStack{
-                            TabView(selection: $selectedTab) {
-                                NavigationStack {
-                                    ZStack{
-                                        Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
-                                        MainView()
-                                    }
-                                }
-                                .tag(0)
-
-                                NavigationStack {
-                                    VStack {
-                                        EmptyView()
-                                    }
-                                    .animation(.easeInOut, value: isCameraViewActive)
-                                    .navigationDestination(isPresented: $isCameraViewNavigate){
-                                        CameraView(chosenFolder: recentlySeenFolder, isCameraSheetOn: $isCameraSheetOn, home: $home)
-                                            .onDisappear {
-                                                if home == true {
-                                                    isCameraViewActive = false
-                                                    home = false
-                                                    selectedTab = recentTag
-                                                }
-                                            }
-                                        }
-                                }
-                                .tag(1)
-                                
-                                NavigationStack {
-                                    ZStack{
-                                        Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
-                                        FolderListView(recentlySeenFolder: $recentlySeenFolder)
-                                    }
-                                }
-                                .tag(2)
-                            }
-                            .onAppear {
-                                UITabBar.appearance().isHidden = true
-                            }
-
-
-                    }
-                    .animation(.easeInOut, value: isCameraViewActive)
-
-                    VStack(spacing: 0) {
-                        Spacer()
-                        HStack(spacing: 0) {
-                            HStack {
-                                Button {
-                                    selectedTab = 0
-                                    recentTag = 0
-                                    recentlySeenFolder = folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil
-                                    page = .main
-                                } label: {
-                                    VStack(spacing: 0) {
-                                        VStack{
-                                            Image(page == .main ? "allTodo.fill" : "allTodo")
-                                                .font(.system(size: 24))
-                                                .aspectRatio(contentMode: .fit)
-                                                .frame(width: 20, height: 20)
-                                        }
-                                        .frame(width: 44, height: 44)
-                                        Text("전체투두")
-                                            .font(.system(size: 12))
-                                            .bold()
-                                    }
-                                    .frame(height: 60)
-                                }
-                                .foregroundStyle(page == .main ? Color("gray/gray-700") : Color("gray/gray-500"))
-                                
-                                Spacer()
-                                
-                                Button {
-                                    selectedTab = 2
-                                    recentTag = 2
-                                    page = .folder
-                                    recentlySeenFolder = folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil
-                                } label: {
-                                    VStack(spacing: 0) {
-                                        VStack {
-                                            Image(systemName: page == .folder ? "folder.fill" : "folder")
-                                                .font(.system(size: 24))
-                                                .aspectRatio(contentMode: .fit)
-                                        }
-                                        .frame(width: 44, height: 44)
-                                        Text("폴더")
-                                            .font(.system(size: 12))
-                                            .bold()
-                                    }
-                                    .frame(height: 60)
-                                }
-                                .foregroundStyle(page == .folder ? Color("gray/gray-700") : Color("gray/gray-500"))
-                            }
-                            .padding(.horizontal, 42)
-                            .padding(.bottom, 23)
+        ZStack(alignment: .bottom) {
+            VStack{ // 메모리에 적재되어 네비게이션 되고 있는 뷰들을 탭바로 관리함
+                TabView(selection: $selectedTab) {
+                    NavigationStack {
+                        ZStack{
+                            Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
+                            MainView()
                         }
-                        .background(Color.white)
                     }
-                    .animation(.easeInOut, value: isCameraViewActive)
-                    .opacity(isCameraViewActive ? 0 : 1)
+                    .tag(0)
                     
-                    HStack {
-                        Button  {
-                            selectedTab = 1
-                            isCameraViewActive = true
-                            DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
-                                isCameraViewNavigate = true
-                            }
-                        } label:  {
-                            ZStack{
-                                Circle()
-                                    .frame(width: 78, height: 78)
-                                    .foregroundStyle(Color.white)
-                                    .shadow(color: .lightGray, radius: 10)
-                                VStack {
-                                    Image("cloverCamera.fill")
-                                        .font(.system(size: 40))
-                                        .aspectRatio(contentMode: .fill)
-                                        .foregroundStyle(Color("green/green-400"))
-                                }
-                                .frame(width: 48, height: 48)
-                            }
+                    NavigationStack {
+                        VStack {
+                            EmptyView()
                         }
-                        .offset(y: -42)
+                        .animation(.easeInOut, value: isCameraViewActive)
+                        .navigationDestination(isPresented: $isCameraViewNavigate){
+                            CameraView(chosenFolder: recentlySeenFolder, isCameraSheetOn: $isCameraSheetOn, home: $home)
+                                .onDisappear {
+                                    if home == true {
+                                        isCameraViewActive = false
+                                        home = false
+                                        selectedTab = recentTag
+                                    }
+                                }
+                        }
                     }
-                    .opacity(isCameraViewActive ? 0 : 1)
-                    .animation(.easeInOut, value: isCameraViewActive)
+                    .tag(1)
+                    
+                    NavigationStack {
+                        ZStack{
+                            Color("gray/gray-200").ignoresSafeArea(.all, edges: .top)
+                            FolderListView(recentlySeenFolder: $recentlySeenFolder)
+                        }
+                    }
+                    .tag(2)
                 }
-
-            .edgesIgnoringSafeArea(.bottom)
-            .ignoresSafeArea(.keyboard)
+                .onAppear {
+                    UITabBar.appearance().isHidden = true
+                }
+                
+                
+            }
+            .animation(.easeInOut, value: isCameraViewActive)
+            
+            VStack(spacing: 0) { // 커스텀 탭바 뷰
+                Spacer()
+                HStack(spacing: 0) {
+                    HStack {
+                        Button { // 전체 투두 탭
+                            selectedTab = 0
+                            recentTag = 0
+                            recentlySeenFolder = folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil
+                            page = .main
+                        } label: {
+                            VStack(spacing: 0) {
+                                VStack{
+                                    Image(page == .main ? "allTodo.fill" : "allTodo")
+                                        .font(.system(size: 24))
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: 20, height: 20)
+                                }
+                                .frame(width: 44, height: 44)
+                                Text("전체투두")
+                                    .font(.system(size: 12))
+                                    .bold()
+                            }
+                            .frame(height: 60)
+                        }
+                        .foregroundStyle(page == .main ? Color("gray/gray-700") : Color("gray/gray-500"))
+                        
+                        Spacer()
+                        
+                        Button { //카메라 탭
+                            selectedTab = 2
+                            recentTag = 2
+                            page = .folder
+                            recentlySeenFolder = folders.count > 0 ? folders.first(where: {$0.id.uuidString == defaultFolderID}) : nil
+                        } label: {
+                            VStack(spacing: 0) {
+                                VStack {
+                                    Image(systemName: page == .folder ? "folder.fill" : "folder")
+                                        .font(.system(size: 24))
+                                        .aspectRatio(contentMode: .fit)
+                                }
+                                .frame(width: 44, height: 44)
+                                Text("폴더")
+                                    .font(.system(size: 12))
+                                    .bold()
+                            }
+                            .frame(height: 60)
+                        }
+                        .foregroundStyle(page == .folder ? Color("gray/gray-700") : Color("gray/gray-500"))
+                    }
+                    .padding(.horizontal, 42)
+                    .padding(.bottom, 23)
+                }
+                .background(Color.white)
+            }
+            .animation(.easeInOut, value: isCameraViewActive)
+            .opacity(isCameraViewActive ? 0 : 1)
+            
+            HStack { //탭바의 카메라 버튼
+                Button  {
+                    selectedTab = 1
+                    isCameraViewActive = true
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+                        isCameraViewNavigate = true
+                    }
+                } label:  {
+                    ZStack{
+                        Circle()
+                            .frame(width: 78, height: 78)
+                            .foregroundStyle(Color.white)
+                            .shadow(color: .lightGray, radius: 10)
+                        VStack {
+                            Image("cloverCamera.fill")
+                                .font(.system(size: 40))
+                                .aspectRatio(contentMode: .fill)
+                                .foregroundStyle(Color("green/green-400"))
+                        }
+                        .frame(width: 48, height: 48)
+                    }
+                }
+                .offset(y: -42)
+            }
+            .opacity(isCameraViewActive ? 0 : 1)
+            .animation(.easeInOut, value: isCameraViewActive)
+        }
+        
+        .edgesIgnoringSafeArea(.bottom)
+        .ignoresSafeArea(.keyboard)
         
         .fullScreenCover(isPresented: $isOnboarindViewActive) {
             OnboardingView()

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -182,11 +182,9 @@ struct TodoGridView: View {
             NavigationStack{
                 CameraView(chosenFolder: currentFolder, isCameraSheetOn: $isCameraSheetOn, home: $home)
                     .toolbar {
-                        if !isCameraSheetOn {
-                            ToolbarItem(placement: .navigationBarLeading) {
-                                Button("취소") {
-                                    print("Edit tapped")
-                                }
+                        ToolbarItem(placement: .navigationBarLeading) {
+                            Button("취소") {
+                                isCameraNavigate = false
                             }
                         }
                     }

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -59,6 +59,7 @@ struct TodoGridView: View {
     
     /// 카메라 뷰 진입시 필요한 변수임. False일 때는 sheet에서 진입하는 것이 아님, true일 때는 sheet에서 진입함. 두 개 상황에서 뷰가 다르게 그려짐.
     @State private var isCameraSheetOn: Bool = false
+    @State private var isCameraNavigate: Bool = false
     
     private var compositeTodos: [Todo] {
         folders.flatMap { $0.todos }
@@ -165,10 +166,9 @@ struct TodoGridView: View {
             toastHeight = UIScreen.main.bounds.height / 2 - 127 - 50
         }
         .confirmationDialog("포토투두 추가 방법 선택", isPresented: $isShowingOptions, titleVisibility: .visible) {
-            NavigationLink{
-                CameraView(chosenFolder: currentFolder, isCameraSheetOn: $isCameraSheetOn, home: $home)
-            } label : {
-                Text("촬영하기")
+            Button("촬영하기") {
+                isCameraNavigate = true
+                home = false
             }
             Button("앨범에서 가져오기"){
                 cameraVM.photoData.removeAll()
@@ -178,6 +178,21 @@ struct TodoGridView: View {
         .photosPicker(isPresented: $showingImagePicker, selection: $selectedItems,  maxSelectionCount: 10, matching: .not(.videos))
         .onChange(of: selectedItems, loadImage)
         .navigationBarHidden( viewType == .main ? true : false)
+        .sheet(isPresented: $isCameraNavigate, content: {
+            NavigationStack{
+                CameraView(chosenFolder: currentFolder, isCameraSheetOn: $isCameraSheetOn, home: $home)
+                    .toolbar {
+                        if !isCameraSheetOn {
+                            ToolbarItem(placement: .navigationBarLeading) {
+                                Button("취소") {
+                                    print("Edit tapped")
+                                }
+                            }
+                        }
+                    }
+                    .presentationDragIndicator(.visible)
+            }
+        })
         .sheet(isPresented: $isDoneSelecting, content: {
             NavigationStack{
                 VStack{
@@ -187,7 +202,6 @@ struct TodoGridView: View {
                     }
                 }
             }
-            
         })
         .toolbar {
             ToolbarItem {

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -30,7 +30,6 @@ enum ToastOption {
 struct TodoGridView: View {
     @Environment(\.modelContext) private var modelContext
     @Query private var folders: [Folder]
-    @Query private var compositeTodos: [Todo]
     @State var currentFolder: Folder? = nil
     var viewType: TodoGridViewType
     @State private var selectedTodos = Set<UUID>()
@@ -61,19 +60,18 @@ struct TodoGridView: View {
     /// 카메라 뷰 진입시 필요한 변수임. False일 때는 sheet에서 진입하는 것이 아님, true일 때는 sheet에서 진입함. 두 개 상황에서 뷰가 다르게 그려짐.
     @State private var isCameraSheetOn: Bool = false
     
+    private var compositeTodos: [Todo] {
+        folders.flatMap { $0.todos }
+    }
     
     private var todos: [Todo] {
         switch viewType {
         case .singleFolder:
             return currentFolder?.todos.filter { !$0.isDone } ?? []
         case .main:
-            return compositeTodos.filter { todo in
-                todo.isDone == false
-            }
+            return compositeTodos.filter { !$0.isDone }
         case .doneList:
-            return compositeTodos.filter { todo in
-                todo.isDone == true
-            }
+            return compositeTodos.filter { $0.isDone }
         }
     }
     

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -178,10 +178,17 @@ struct TodoGridView: View {
         .photosPicker(isPresented: $showingImagePicker, selection: $selectedItems,  maxSelectionCount: 10, matching: .not(.videos))
         .onChange(of: selectedItems, loadImage)
         .navigationBarHidden( viewType == .main ? true : false)
-        //PhotosPicker에서 아이템 선택 완료 시, isActive가 true로 바뀌고, MakeTodoView로 전환됨
-        .navigationDestination(isPresented: $isDoneSelecting) {
-            MakeTodoView(chosenFolder: $currentFolder, startViewType: viewType == .singleFolder ? .gridSingleFolder : .gridMain , contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
-        }
+        .sheet(isPresented: $isDoneSelecting, content: {
+            NavigationStack{
+                VStack{
+                    ScrollView{
+                        MakeTodoView(chosenFolder: $currentFolder, startViewType: .camera, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
+                            .presentationDragIndicator(.visible)
+                    }
+                }
+            }
+            
+        })
         .toolbar {
             ToolbarItem {
                 //편집모드에서 다중선택된 아이템 삭제

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -197,6 +197,13 @@ struct TodoGridView: View {
                     ScrollView{
                         MakeTodoView(chosenFolder: $currentFolder, startViewType: .camera, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
                             .presentationDragIndicator(.visible)
+                            .toolbar {
+                                ToolbarItem(placement: .navigationBarLeading) {
+                                    Button("취소") {
+                                        isDoneSelecting = false
+                                    }
+                                }
+                            }
                     }
                 }
             }

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -166,7 +166,7 @@ struct TodoGridView: View {
         }
         .confirmationDialog("포토투두 추가 방법 선택", isPresented: $isShowingOptions, titleVisibility: .visible) {
             NavigationLink{
-                CameraView(chosenFolder: currentFolder, isCameraSheetOn: $isCameraSheetOn)
+                CameraView(chosenFolder: currentFolder, isCameraSheetOn: $isCameraSheetOn, home: $home)
             } label : {
                 Text("촬영하기")
             }


### PR DESCRIPTION
## 관련 이슈
- #93 
- 메인 뷰(+완료함 뷰)에서 `Leading NavigationBar`에 위치한 `Toolbar`의 추가 버튼이나 편집 버튼을 눌렀을 때 UI 행이 평균적으로 `1s~ 1.5s`정도 발생하였습니다. 또한, 메인 뷰의 초기 렌더링 시에도 비슷한 정도의 행이 발생하였습니다. (참고로 제 데이터상으로 50개 정도의 투두 아이템을 갖고 있었습니다.)

## 변경 사항1: 투두 Query 방식 변경
이리저리 원인 파악을 해보니, 투두 아이템을 쿼리해오는 방식이 문제인 것이 확실해 졌습니다. 그 근거는, ` 메인 뷰(혹은 완료함 뷰)`와 `폴더 리스트 뷰에서 진입한 그리드 뷰`가 똑같은 방식으로 짜여진 뷰임에도 불구하고, 전자에서는 행이 발생하고, 후자에서는 행이 발생하지 않았기 때문입니다. 두 뷰에서 투두 아이템을 가져오는 방식은 아래와 같은 차이가 있었습니다.

```Swift
    private var todos: [Todo] {
        switch viewType {
        case .singleFolder:
            return currentFolder?.todos.filter { !$0.isDone } ?? []
        case .main:
            return compositeTodos.filter { todo in
                todo.isDone == false
            }
        case .doneList:
            return compositeTodos.filter { todo in
                todo.isDone == true
            }
        }
    }
```

`singleFolder` 타입의 경우에는 폴더에서부터 폴더 내부에 있는 `todos`로 접근하는데 반해, `main` 혹은 `doneList`의 경우는 `compositeTodos`라는 것으로부터 직접 필터링을 해오고 있었습니다. 그리고 이 `compositeTodos`는 ` @Query private var compositeTodos: [Todo]` 라는 명령어를 통해 불러와지고 있었습니다. 프로파일러에서도 `Heaviest Stack Trace`에서 `compositeTodos.getter` 부분에서 가장 많은 시간이 소요되는 것을 확인할 수 있었습니다.
<img width="516" alt="image" src="https://github.com/user-attachments/assets/28881cff-11cd-491a-85c0-e4b29ba2ef47" />

쿼리 부분이 문제이다보니 쿼리를 최적화하면 어떨까 생각이 들어, `computed variable`로 하던 필터링 로직과 정렬을 쿼리에서 직접 하는 식으로 쿼리 최적화를 해보려고 했지만 여전히 문제는 해결되지 않았습니다. 그러다가 문득 '폴더에서 접근하면 빠르고, 하나씩 다 불러오는 쿼리에서는 느리니, 폴더로 불러온 것들을 합친다면 어떨까?'하는 생각이 들어, 아래와 같이 `computed variable`로 만들어 보았더니 fetch 속도가 확실히 개선되는 것을 확인할 수 있었습니다.

```Swift
    private var compositeTodos: [Todo] {
        folders.flatMap { $0.todos }
    }
```

결과가 너무 신기해서 GPT한테 물어보니 아래와 같은 답변을 해주었습니다.

**응답 속도가 개선된 이유는 데이터 조회와 필터링 방식의 차이에 있습니다. 아래는 그 이유입니다:**

1. **즉시 로딩 vs. 지연 필터링**
   - `@Query todos: [Todo]` 방식:
     - 모든 Todo 객체를 직접 데이터베이스나 SwiftData 컨텍스트에서 가져옵니다.
     - `.filter`를 사용해 필터링하면 데이터가 많을수록 느려집니다.
   - **계산된 변수(compositeTodos) 방식:**
     - 폴더를 먼저 접근하고 `flatMap`과 `filter`를 사용해 데이터를 처리합니다.
     - 폴더와 Todo가 지연 로딩되거나 캐시될 경우, 더 효율적인 메모리 접근이 가능합니다.
     - Swift의 `flatMap`과 `filter` 같은 고차 함수는 메모리에 있는 컬렉션을 처리할 때 더 효율적입니다.

2. **효율적인 데이터 접근 패턴**
   - 모든 Todo 객체를 직접 가져오면 데이터베이스 인덱스를 제대로 활용하지 못해 느려질 수 있습니다.
   - 폴더를 통해 Todo에 접근하면 더 효율적인 사전 로딩(prefetching)이나 접근 패턴을 사용할 수 있습니다.

3. **컨텍스트 전환 감소**
   - `@Query`는 SwiftData의 관리 객체와 Swift 구조체 사이의 전환이 필요해 오버헤드가 발생할 수 있습니다.
   - 계산된 변수는 폴더에 직접 접근해 이런 오버헤드를 줄입니다.

### **요약**
계산된 변수가 더 빠른 이유는 다음과 같습니다:
- 효율적인 메모리 접근과 지연 로딩 가능성.
- 컨텍스트 관리 오버헤드 감소.
- Swift의 고차 함수를 활용한 간소화된 필터링.

이 패턴은 메모리 내에서 데이터를 처리해 매번 데이터베이스에서 조회하는 병목을 방지합니다. 👍

이렇게 쉽게 마무리될 줄 알았는데,  새로운 문제가 생겼습니다. 탭바에서 `mainView`와 `FolderListView` 사이를 빠르게 전환할 때 전에 보지 못했던 오류가 나면서 앱이 크래쉬가 났습니다.
<img width="720" alt="image" src="https://github.com/user-attachments/assets/22bc8204-c778-4050-8833-9ca6c3b21eed" />
`Todo`의 `createdAt` 속성에 접근할 수 없다는 내용입니다.
<img width="998" alt="image" src="https://github.com/user-attachments/assets/7a7e2833-aef2-4c70-9875-3bef9a7f3571" />
메모리 해제가 되는 중간에 누수가 발생했다는 내용입니다.

## 변경 사항2: 탭바 리팩토링
탭바를 빠르게 전환하면서 문제가 생긴 것어서 탭바의 코드를 한번 보았는데,  (제가 이해한 바가 맞다면) 페이지를 전환할 때마다 매번 뷰를 새로 생성하는 방식으로 되어 있는 것처럼 보였고, 이 부분에서 메모리 해제와 관련된 문제가 생긴 것 같았습니다. 

```Swift
//기존 탭바 내부의 코드 일부
                if page == .main {
                    MainView()
                } else if page == .folder {
                    FolderListView()
                }
```

검증되지 않은 가설이기는 하나, `init` -> `denint` 사이에 약간의 간극이 있는데, 한쪽 뷰에서 `deinit`되는 와중에 다른 뷰에서 다시 접근하려고 하기 때문에 오류가 생기는 듯했습니다. 기존에는 Query를 통해서 안정적으로 `Todo`에 접근했지만, 조금 더 빠르기는 하나 일반적이지는 않은 방식으로 접근하기에 문제가 생기는 것 같았습니다. 방법이 없을까 고민하던 중, 혹시 몰라서 애플의 기본 컴포넌트인 `TabView`로 해도 똑같은 문제가 일어날까 궁금해서 테스트를 해보았더니 문제가 일어나지 않았습니다 😱 그래서 애플의 기본 컴포넌트인 `TabView`를 사용하는 방식으로 탭바 리팩토링을 진행했습니다. 그런데 정말 쉽지 않더라구요. 네비게이션 지옥이라고 할 정도로 하나가 되는듯 하면 다른게 안되고.. 😅 삽질을 거듭하면서 겨우겨우 기존 방식과 유사한 동작을 구현해낼 수 있었습니다. 룰루께서 탭바때문에 고생을 정말 많이 하셨다는걸 새삼스럽게 다시 느낄 수 있었습니다. 이제는 탭바를 뒷편에 살려 놓고, ZStack으로 그 앞의 버튼으로 탭바의 tag를 변경하면서 화면을 바꾸는 방식으로 작동합니다. 이제는 영상에서처럼 빠르게 탭바를 왔다갔다할 수 있습니다.

https://github.com/user-attachments/assets/f78e035f-dd6e-4e34-8fd4-219c55ffbdfa


## 변경 사항3: 툴바 버튼을 통한 투두 아이템 추가 방식 변경 (네비게이션 방식 -> sheet 방식)
기존에는 툴바 버튼에서 투두 아이템을 추가할 때 네비게이션 방식으로 `CameraView`나 `MakeTodoView`로 넘어갔는데요, 탭바의 작동 방식을 변경하면서, 어떻게든 기존 방식과 유사하게 뷰가 작동하도록 하려고 했으나, 변경된 코드로는 네비게이션 방식으로 추가할 때 탭바를 숨기는 게 더이상 불가능했습니다. 그래서 sheet를 통해서 투두 아이템을 추가하는 방식으로 변경했는데, 이 부분은 먼저 말씀드리지 못해 죄송합니다. 큰 차이는 없어 보여서 일단 PR과 테스트플라이트를 통해 피드백을 받아보고자 합니다.
https://github.com/user-attachments/assets/125cbaef-b193-4be8-b375-abbdfda2f7ee


## 변경 사항4: 카메라 뷰 진입 시 폴더가 반영되도록 설정
카메라 뷰에 진입할 때 캐러샐 뷰에 폴더가 반영되어 있지 않아서, 바로 현재 폴더가 선택되어 있을 수 있도록 변경했습니다.
https://github.com/user-attachments/assets/97a01e28-0728-44c5-a421-6b59ace8911b


## 정리
마지막으로 프로파일러로 확인했을 때 행 부분이 많이 줄어있는 것을 확인하였습니다. 노란색이나 빨간색으로 점철되어 있던 프로파일러가 파란색이 가끔씩 나오는 정도가 되었습니다!
<img width="1406" alt="image" src="https://github.com/user-attachments/assets/5730087d-27a8-4040-b06f-9719326fa348" />
