### PR TITLE
쉐어 익스텐션에 폴더 선택 및 메모 추가 기능 구현

### DIFF
--- a/PhotoTodo.xcodeproj/project.pbxproj
+++ b/PhotoTodo.xcodeproj/project.pbxproj
@@ -546,7 +546,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.4;
+				MARKETING_VERSION = 1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -590,7 +590,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.4;
+				MARKETING_VERSION = 1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PhotoTodo.xcodeproj/project.pbxproj
+++ b/PhotoTodo.xcodeproj/project.pbxproj
@@ -30,6 +30,10 @@
 		1A619E4A2C7DC68A0082FD5C /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A619E492C7DC68A0082FD5C /* ToastView.swift */; };
 		1A8584012D435EC600092B0E /* FolderRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8584002D435EBA00092B0E /* FolderRowView.swift */; };
 		1A8584032D435F0000092B0E /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8584022D435EFB00092B0E /* ActionButton.swift */; };
+		1ACE61902D92E10800090C27 /* FolderManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A27017D2D62C35900DA8892 /* FolderManager.swift */; };
+		1ACE61912D92E2D200090C27 /* FolderCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E5C832C5B573400BAFD13 /* FolderCarouselView.swift */; };
+		1ACE61922D92E32400090C27 /* FolderEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F46B28A2C5C7E2100556646 /* FolderEditView.swift */; };
+		1ACE61932D92E33800090C27 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A2778E32C56395A00A02C7E /* Assets.xcassets */; };
 		1AFB127E2C69C22D00952121 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 1AFB127D2C69C22D00952121 /* Collections */; };
 		1AFB12A42C77243A00952121 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFB12A32C77243A00952121 /* ShareViewController.swift */; };
 		1AFB12A72C77243A00952121 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 1AFB12A62C77243A00952121 /* Base */; };
@@ -91,6 +95,7 @@
 		1A619E492C7DC68A0082FD5C /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		1A8584002D435EBA00092B0E /* FolderRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderRowView.swift; sourceTree = "<group>"; };
 		1A8584022D435EFB00092B0E /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
+		1ACE61942D92F0EF00090C27 /* PhotoTodoRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PhotoTodoRelease.entitlements; sourceTree = "<group>"; };
 		1AFB12A12C77243A00952121 /* ShareImage.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareImage.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		1AFB12A32C77243A00952121 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		1AFB12A62C77243A00952121 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
@@ -165,6 +170,7 @@
 		1A2778DC2C56395900A02C7E /* PhotoTodo */ = {
 			isa = PBXGroup;
 			children = (
+				1ACE61942D92F0EF00090C27 /* PhotoTodoRelease.entitlements */,
 				1AFB12B42C7724BC00952121 /* PhotoTodo.entitlements */,
 				3CC113B42C72036100281EBD /* Info.plist */,
 				3C90390C2C623EFF00025335 /* Date+Extension.swift */,
@@ -315,6 +321,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1ACE61932D92E33800090C27 /* Assets.xcassets in Resources */,
 				1AFB12A72C77243A00952121 /* Base in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -359,7 +366,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1ACE61912D92E2D200090C27 /* FolderCarouselView.swift in Sources */,
+				1ACE61902D92E10800090C27 /* FolderManager.swift in Sources */,
 				1AFB12B22C77245500952121 /* PhotoTodoModel.swift in Sources */,
+				1ACE61922D92E32400090C27 /* FolderEditView.swift in Sources */,
 				1AFB12A42C77243A00952121 /* ShareViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -513,10 +523,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = PhotoTodo/PhotoTodo.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PhotoTodo/Preview Content\"";
-				DEVELOPMENT_TEAM = 2J2UA8CPHM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2J2UA8CPHM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PhotoTodo/Info.plist;
@@ -538,6 +550,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = PhotoTodoProfile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -552,12 +565,14 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = PhotoTodo/PhotoTodo.entitlements;
+				CODE_SIGN_ENTITLEMENTS = PhotoTodo/PhotoTodoRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PhotoTodo/Preview Content\"";
-				DEVELOPMENT_TEAM = 2J2UA8CPHM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2J2UA8CPHM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PhotoTodo/Info.plist;
@@ -579,6 +594,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = PhotoTodoProfile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -592,9 +608,11 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareImage/ShareImage.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2J2UA8CPHM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2J2UA8CPHM;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShareImage/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ShareImage;
@@ -609,6 +627,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo.ShareImage";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = PhotoTodoShareExtensionProvisioningProfile;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -623,9 +642,11 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareImage/ShareImage.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2J2UA8CPHM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2J2UA8CPHM;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShareImage/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ShareImage;
@@ -640,6 +661,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo.ShareImage";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = PhotoTodoShareExtensionProvisioningProfile;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/PhotoTodo/FolderCarouselView.swift
+++ b/PhotoTodo/FolderCarouselView.swift
@@ -34,6 +34,7 @@ func changeStringToColor(colorName: String) -> Color {
 }
 
 struct FolderCarouselView: View {
+    @Environment(\.modelContext) private var modelContext
     @Binding var chosenFolder: Folder?
     @State private var selectedButtonIndex: Int = 0
     //#if DEBUG
@@ -127,6 +128,9 @@ struct FolderCarouselView: View {
             }
         }
         .frame(height: 34)
+        .onAppear {
+            folderManager.setDefaultFolder(modelContext, folderOrders, folders)
+        }
         .sheet(isPresented: $isShowingSheet, content: {
             FolderEditView(isSheetPresented: $isShowingSheet, folderNameInput: $folderNameInput, selectedColor: $selectedColor, selectedFolder: $newFolder)
                 .presentationDetents([.medium, .large])

--- a/PhotoTodo/FolderCarouselView.swift
+++ b/PhotoTodo/FolderCarouselView.swift
@@ -129,7 +129,13 @@ struct FolderCarouselView: View {
         }
         .frame(height: 34)
         .onAppear {
+            if chosenFolder == nil {
+                chosenFolder = folders.first
+            }
             folderManager.setDefaultFolder(modelContext, folderOrders, folders)
+        }
+        .task {
+            folderManager.setFolderOrder(folders, folderOrders, modelContext)
         }
         .sheet(isPresented: $isShowingSheet, content: {
             FolderEditView(isSheetPresented: $isShowingSheet, folderNameInput: $folderNameInput, selectedColor: $selectedColor, selectedFolder: $newFolder)

--- a/PhotoTodo/PhotoTodoApp.swift
+++ b/PhotoTodo/PhotoTodoApp.swift
@@ -39,8 +39,15 @@ struct PhotoTodoApp: App {
 
     var body: some Scene {
         WindowGroup {
-            TabBarView()
+            if let defaults = UserDefaults(suiteName: "group.PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo") {
+                TabBarView()
+                    .defaultAppStorage(defaults)
+            }
+            else {
+                Text("Failed to load UserDefaults")
+            }
         }
         .modelContainer(sharedModelContainer)
     }
 }
+

--- a/PhotoTodo/PhotoTodoRelease.entitlements
+++ b/PhotoTodo/PhotoTodoRelease.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo</string>
+	</array>
+</dict>
+</plist>

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -78,9 +78,7 @@ struct TabBarView: View {
                 }
                 .onAppear {
                     UITabBar.appearance().isHidden = true
-                }
-                
-                
+                }    
             }
             .animation(.easeInOut, value: isCameraViewActive)
             

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -186,11 +186,12 @@ struct TabBarView: View {
                 if defaults?.bool(forKey: "hasBeenLaunched") == false {
                     defaults?.set(true, forKey: "hasBeenLaunched")
                 }
-                return
+            } else {
+                folderManager.setDefaultFolder(modelContext, folderOrders, folders)
             }
-            
-            folderManager.setDefaultFolder(modelContext, folderOrders, folders)
-            hasBeenLaunched = true
+        }
+        .task {
+            folderManager.setFolderOrder(folders, folderOrders, modelContext)
         }
     }
     

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -78,7 +78,7 @@ struct TabBarView: View {
                 }
                 .onAppear {
                     UITabBar.appearance().isHidden = true
-                }    
+                }
             }
             .animation(.easeInOut, value: isCameraViewActive)
             

--- a/PhotoTodo/TabBarView.swift
+++ b/PhotoTodo/TabBarView.swift
@@ -19,7 +19,6 @@ struct TabBarView: View {
     @State private var home: Bool? = false
     
     @State private var page: page = .main
-    @AppStorage("hasBeenLaunched") private var hasBeenLaunched = false
     @Environment(\.modelContext) private var modelContext
     @Query private var folders: [Folder]
     @Query private var folderOrders: [FolderOrder]
@@ -29,6 +28,8 @@ struct TabBarView: View {
     @State var isCameraSheetOn: Bool = false
     // 온보딩뷰
     @Environment(\.presentationMode) var presentationMode
+    
+    @AppStorage("hasBeenLaunched") private var hasBeenLaunched = false
     @AppStorage("onboarding") var isOnboarindViewActive: Bool = true
     @AppStorage("deletionCount") var deletionCount: Int = 0
     
@@ -179,25 +180,17 @@ struct TabBarView: View {
             //MARK: 30일 초과한 아이템을 지움
             removeTodoItemsPastDueDate()
             
-            //MARK: 최초 1회 실행된 적이 있을 시
             if hasBeenLaunched {
+                //포토투두 앱 내부에서만 쓰이는 AppStorage에서 앱 그룹의 유저디폴트 값으로 기본 폴더 생성을 여부를 판단하고자 심어놓은 코드
+                let defaults = UserDefaults(suiteName: "group.PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo")
+                if defaults?.bool(forKey: "hasBeenLaunched") == false {
+                    defaults?.set(true, forKey: "hasBeenLaunched")
+                }
                 return
             }
             
-            //MARK: 최초 1회 실행된 적 없을 시 세팅 작업 실행
-            let defaultFolder = Folder(
-                id: UUID(),
-                name: "기본",
-                color: "green",
-                todos: []
-            )
-            modelContext.insert(defaultFolder)
+            folderManager.setDefaultFolder(modelContext, folderOrders, folders)
             hasBeenLaunched = true
-            
-            manager.requestAuthorization()
-            
-            //MARK: 폴더 순서 정렬 관련 안정화 코드
-            folderManager.setFolderOrder(folders, folderOrders, modelContext)
         }
     }
     

--- a/PhotoTodo/ViewModel/FolderManager.swift
+++ b/PhotoTodo/ViewModel/FolderManager.swift
@@ -75,21 +75,25 @@ struct FolderManager {
         try? modelContext.save()
     }
     
-    func setDefaultFolder(_ modelContext: ModelContext, _ folderOrders: [FolderOrder], _ folders: [Folder]) {
+    func setDefaultFolder(_ modelContext: ModelContext,_  folderOrders: [FolderOrder], _ folders: [Folder]) {
            let defaults = UserDefaults(suiteName: "group.PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo")
            if defaults?.bool(forKey: "hasBeenLaunched") == false {
-               DispatchQueue.main.async {
-                   let defaultFolder = Folder(
-                       id: UUID(),
-                       name: "기본",
-                       color: "green",
-                       todos: []
-                   )
-                   modelContext.insert(defaultFolder)
-                   setFolderOrder(folders, folderOrders, modelContext)
-                   try? modelContext.save()
-                   defaults?.set(true, forKey: "hasBeenLaunched")
+               if folderOrders.count == 0 {
+                   let folderOrder = FolderOrder()
+                   modelContext.insert(folderOrder)
                }
+               
+               let defaultFolder = Folder(
+                   id: UUID(),
+                   name: "기본",
+                   color: "green",
+                   todos: []
+               )
+               
+               modelContext.insert(defaultFolder)
+               setFolderOrder(folders, folderOrders, modelContext)
+               defaults?.set(true, forKey: "hasBeenLaunched")
+                try? modelContext.save()
            } else {
                print("UserDefaults key가 이미 있음")
            }

--- a/PhotoTodo/ViewModel/FolderManager.swift
+++ b/PhotoTodo/ViewModel/FolderManager.swift
@@ -18,7 +18,7 @@ struct FolderManager {
             try? modelContext.save()
         }
     }
-
+    
     func getOrderedFolder(_ folders: [Folder], _ folderOrders: [FolderOrder]) -> [Folder] {
         guard let order = folderOrders.first?.uuidOrder else { return folders }
         let folderDict = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
@@ -51,7 +51,7 @@ struct FolderManager {
             try? modelContext.save()
         }
     }
-
+    
     func saveFolder(_ folderOrders: [FolderOrder], _ folderNameInput: String, _ selectedFolder: Folder?, _ selectedColor: Color?, _ modelContext: ModelContext){
         if folderNameInput == "" {
             return
@@ -69,11 +69,31 @@ struct FolderManager {
                 folderOrders.first?.uuidOrder.append(newFolder.id)
             }
         } else { // 바인딩된 폴더가 존재 -> 폴더 수정
-                selectedFolder?.name = folderNameInput
-                selectedFolder?.color = selectedColor != nil ? colorDictionary[selectedColor!, default: "green"] : "green"
-            }
+            selectedFolder?.name = folderNameInput
+            selectedFolder?.color = selectedColor != nil ? colorDictionary[selectedColor!, default: "green"] : "green"
+        }
         try? modelContext.save()
     }
+    
+    func setDefaultFolder(_ modelContext: ModelContext, _ folderOrders: [FolderOrder], _ folders: [Folder]) {
+           let defaults = UserDefaults(suiteName: "group.PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo")
+           if defaults?.bool(forKey: "hasBeenLaunched") == false {
+               DispatchQueue.main.async {
+                   let defaultFolder = Folder(
+                       id: UUID(),
+                       name: "기본",
+                       color: "green",
+                       todos: []
+                   )
+                   modelContext.insert(defaultFolder)
+                   setFolderOrder(folders, folderOrders, modelContext)
+                   try? modelContext.save()
+                   defaults?.set(true, forKey: "hasBeenLaunched")
+               }
+           } else {
+               print("UserDefaults key가 이미 있음")
+           }
+       }
 }
 
 let colorDictionary: [Color: String] = [

--- a/ShareImage/ShareViewController.swift
+++ b/ShareImage/ShareViewController.swift
@@ -14,14 +14,31 @@ class ShareViewController: SLComposeServiceViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // 이 자리에 공유 뷰의 구성 자리가 나옴
-        isModalInPresentation = true
-        
-        if let itemProviders = (extensionContext!.inputItems.first as? NSExtensionItem)?.attachments {
-            let hostingView = UIHostingController(rootView: ShareView(itemProviders: itemProviders, extensionContext: extensionContext))
-            hostingView.view.frame = view.frame
-            view.addSubview(hostingView.view)
+        do{
+            // 📌 App Group 기반 SwiftData Configuration
+           let config = ModelConfiguration(
+               groupContainer: .identifier("group.PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo")
+           )
+           let container = try ModelContainer(
+               for: Folder.self, FolderOrder.self, Todo.self, Options.self,
+               configurations: config
+           )
+           let context = ModelContext(container)
+
+            if let itemProviders = (extensionContext!.inputItems.first as? NSExtensionItem)?.attachments {
+                let shareView = ShareView(
+                                itemProviders: itemProviders,
+                                extensionContext: extensionContext
+                            )
+                            .modelContainer(container)
+                let hostingView = UIHostingController(rootView: shareView)
+                hostingView.view.frame = view.frame
+                view.addSubview(hostingView.view)
+            }
+    //        let screenCaptureView =
+        }  catch {
+            fatalError("Failed to configure SwiftData container.")
         }
-//        let screenCaptureView =
     }
 }
 
@@ -30,7 +47,8 @@ struct ShareView: View {
     var itemProviders: [NSItemProvider]
     var extensionContext: NSExtensionContext?
     @State private var items: [ImageItem] = []
-    @Query private var folders: [Folder]
+    @State private var chosenFolder: Folder? = nil
+    
     //    @State var defaultFolder: Folder = Folder(id: UUID(), name: "임시저장폴더", color: "green", todos: [])
     
     var body: some View {
@@ -57,29 +75,7 @@ struct ShareView: View {
                 .padding(.vertical, 10)
                 .frame(maxWidth: .infinity)
                 
-                
-//                Text("이미지 Todo 추가")
-//                    .font(.title3.bold())
-//                    .frame(maxWidth: .infinity)
-//                    .overlay(alignment: .leading) {
-//                        HStack{
-//                            Button("취소"){
-//                                dismiss()
-//                            }
-//                            .tint(.red)
-//                            Spacer()
-//                            Button {
-//                                saveItems()
-//                            } label: {
-//                                Text("저장")
-//                                    .font(.title3)
-//                                    .fontWeight(.semibold)
-//                                    .padding(.vertical, 10)
-//                                    .frame(maxWidth: .infinity)
-//                            }
-//                        }
-//                    }
-//                    .padding(.bottom, 10)
+                FolderCarouselView(chosenFolder: $chosenFolder)
                 
                 ScrollView(.horizontal) {
                     HStack {
@@ -105,9 +101,6 @@ struct ShareView: View {
                 //                defaultFolder = folders.first ?? Folder(id: UUID(), name: "임시저장폴더", color: "green", todos: [])
             })
         }
-        .onAppear(perform: {
-            print("폴더 : \(folders)")
-        })
     }
     
     func extractItems(size: CGSize) {
@@ -155,7 +148,7 @@ struct ShareView: View {
             // SwiftData에 저장된 Folder의 기본폴더로 초기화 저장됨
             let fetchDescriptor = FetchDescriptor<Folder>()
             let result = try context.fetch(fetchDescriptor)
-            let newTodo = Todo(folder: result.first ?? Folder(id: UUID(), name: "기본", color: "green", todos: []), id: UUID(), images: imageData, createdAt: Date(), options: Options(), isDone: false)
+            let newTodo = Todo(folder: chosenFolder ?? result.first ?? Folder(id: UUID(), name: "기본", color: "green", todos: []), id: UUID(), images: imageData, createdAt: Date(), options: Options(), isDone: false)
             context.insert(newTodo)
             try context.save()
             dismiss()

--- a/ShareImage/ShareViewController.swift
+++ b/ShareImage/ShareViewController.swift
@@ -10,7 +10,7 @@ import Social
 import SwiftData
 import UniformTypeIdentifiers
 
-class ShareViewController: SLComposeServiceViewController {
+class ShareViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // 이 자리에 공유 뷰의 구성 자리가 나옴
@@ -48,6 +48,7 @@ struct ShareView: View {
     var extensionContext: NSExtensionContext?
     @State private var items: [ImageItem] = []
     @State private var chosenFolder: Folder? = nil
+    @State private var inputText = ""
     
     //    @State var defaultFolder: Folder = Folder(id: UUID(), name: "임시저장폴더", color: "green", todos: [])
     
@@ -91,7 +92,7 @@ struct ShareView: View {
                 .scrollTargetBehavior(.viewAligned)
                 .frame(height: 300) // 이미지 사진 크기를 줄일 때 사용됨
                 .scrollIndicators(.hidden)
-                
+                TextField("메모를 입력하세요", text: $inputText)
                 Spacer(minLength: 0)
             }
             .padding(15)
@@ -148,7 +149,7 @@ struct ShareView: View {
             // SwiftData에 저장된 Folder의 기본폴더로 초기화 저장됨
             let fetchDescriptor = FetchDescriptor<Folder>()
             let result = try context.fetch(fetchDescriptor)
-            let newTodo = Todo(folder: chosenFolder ?? result.first ?? Folder(id: UUID(), name: "기본", color: "green", todos: []), id: UUID(), images: imageData, createdAt: Date(), options: Options(), isDone: false)
+            let newTodo = Todo(folder: chosenFolder ?? result.first ?? Folder(id: UUID(), name: "기본", color: "green", todos: []), id: UUID(), images: imageData, createdAt: Date(), options: Options(memo: inputText), isDone: false)
             context.insert(newTodo)
             try context.save()
             dismiss()

--- a/ShareImage/ShareViewController.swift
+++ b/ShareImage/ShareViewController.swift
@@ -49,7 +49,6 @@ struct ShareView: View {
     @State private var items: [ImageItem] = []
     @State private var chosenFolder: Folder? = nil
     @State private var inputText = ""
-    
     //    @State var defaultFolder: Folder = Folder(id: UUID(), name: "임시저장폴더", color: "green", todos: [])
     
     var body: some View {
@@ -97,7 +96,6 @@ struct ShareView: View {
             }
             .padding(15)
             .onAppear(perform: {
-                
                 extractItems(size: size)
                 //                defaultFolder = folders.first ?? Folder(id: UUID(), name: "임시저장폴더", color: "green", todos: [])
             })

--- a/ShareImage/ShareViewController.swift
+++ b/ShareImage/ShareViewController.swift
@@ -50,6 +50,7 @@ struct ShareView: View {
     @State private var chosenFolder: Folder? = nil
     @State private var inputText = ""
     //    @State var defaultFolder: Folder = Folder(id: UUID(), name: "임시저장폴더", color: "green", todos: [])
+    @Query var folders: [Folder]
     
     var body: some View {
         GeometryReader {
@@ -132,31 +133,19 @@ struct ShareView: View {
     }
 
     func saveItems() {
-        let schema = Schema([
-            Folder.self,
-            Todo.self,
-            Options.self,
-            FolderOrder.self
-        ])
-        do {
-            let context = try ModelContext(.init(for: schema.self))
-            var imageData : [Data] = []
-            for i in items {
-                imageData.append(i.imageData)
-            }
-            // SwiftData에 저장된 Folder의 기본폴더로 초기화 저장됨
-            let fetchDescriptor = FetchDescriptor<Folder>()
-            let result = try context.fetch(fetchDescriptor)
-            let newTodo = Todo(folder: chosenFolder ?? result.first ?? Folder(id: UUID(), name: "기본", color: "green", todos: []), id: UUID(), images: imageData, createdAt: Date(), options: Options(memo: inputText), isDone: false)
-            context.insert(newTodo)
-            try context.save()
-            dismiss()
-        } catch {
-            fatalError("Could not create ModelContainer: \(error)")
+        var imageData : [Data] = []
+        for i in items {
+            imageData.append(i.imageData)
         }
+        // SwiftData에 저장된 Folder의 기본폴더로 초기화 저장됨
+        let newTodo = Todo(folder: chosenFolder ?? folders.first ?? Folder(id: UUID(), name: "기본", color: "green", todos: []), id: UUID(), images: imageData, createdAt: Date(), options: Options(memo: inputText), isDone: false)
         
-//        let newTodo = Todo(id: UUID(), image: Data(), createdAt: Date(), options: Options(), isDone: false)
-//        modelContext.insert(newTodo)
+        let chosenFolder = chosenFolder ?? folders.first ?? Folder(id: UUID(), name: "기본", color: "green", todos: [])
+
+        chosenFolder.todos.append(newTodo)
+        modelContext.insert(newTodo)
+        try? modelContext.save()
+        
         dismiss()
     }
     


### PR DESCRIPTION
## 관련 이슈
- #121 

## 구현 사항
- 쉐어 익스텐션에서 `CarouselView`를 활용하여 폴더를 선택할 수 있도록 하였습니다.
- 추가로 메모도 입력받을 수 있도록 바꾸었습니다.
- 쉐어 익스텐션에서도 앱의 SwiftData에 접근할 수 있도록 container를 설정하는 코드를 넣었습니다.
- 앱의 최초 진입점이 쉐어 익스텐션일 때에도 기본 폴더가 잘 생성될 수 있도록 코드를 수정하였습니다.

![image](https://github.com/user-attachments/assets/17bc6737-cd3d-4897-8957-ef60b8138746)

