### PR TITLE
iOS26 대응 

### DIFF
--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -345,14 +345,22 @@ struct MakeTodoView: View {
             home = false
         }
         .toolbar(startViewType == .edit ? .hidden : .visible)
-        .toolbar(content: {
+        .toolbar {
             // 완료 및 저장 버튼
-            Button {
-                saveTodoItem()
-            } label: {
-                Text("완료")
+            if #available(iOS 26.0, *) {
+                Button(role: .confirm) {
+                    saveTodoItem()
+                } label : {
+                    Text("test")
+                }
+            } else {
+                Button {
+                    saveTodoItem()
+                } label: {
+                    Text("저장")
+                }
             }
-        })
+        }
         .toolbar(.visible, for: .bottomBar)
         .toolbar{
             ToolbarItemGroup(placement: .bottomBar) {

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -189,8 +189,8 @@ struct MakeTodoView: View {
                                         }
                                     }
                                 }
+                                .frame(height: 44)
                                 .padding(.horizontal, 20)
-                                .padding(.vertical, 12)
                                 .foregroundStyle(Color.black)
                                 
                                 Divider()
@@ -205,10 +205,11 @@ struct MakeTodoView: View {
                                         Spacer()
                                         Text(alarmDataisEmpty ?? true ? "없음" : Date().makeAlarmDate(alarmData: contentAlarm ?? Date()))
                                     }
+                                    .frame(height: 44)
                                     .padding(.horizontal, 20)
-                                    .padding(.vertical, 12)
                                     .foregroundStyle(Color.black)
                                 }
+                                .buttonStyle(.plain)
                                 .sheet(isPresented: $alarmisActive, content: {
                                     VStack{
                                         HStack{
@@ -262,10 +263,11 @@ struct MakeTodoView: View {
                                             .resizable()
                                             .frame(width: 8, height: 12)
                                     }
+                                    .frame(height: 44)
                                     .padding(.horizontal, 20)
-                                    .padding(.vertical, 12)
                                     .foregroundStyle(Color.black)
                                 })
+                                .buttonStyle(.plain)
                                 .sheet(isPresented: $memoisActive, content: {
                                     VStack{
                                         HStack{
@@ -288,7 +290,6 @@ struct MakeTodoView: View {
                                     .presentationDetents([.height(CGFloat(200))])
                                 })
                             }
-                            .padding(.vertical, 8)
                         }
                         .clipShape(RoundedRectangle(cornerRadius: 20))
                     }

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -159,48 +159,36 @@ struct MakeTodoView: View {
                             List {
                                 Section{
                                     // 폴더 선택 행
-                                    HStack{
+                                    HStack {
                                         Text("폴더")
                                         Spacer()
-                                        Group{
-                                            Circle()
-                                                .frame(width: 12, height: 12)
-                                                .foregroundStyle(chosenFolderColor)
-                                            
-                                            Menu {
-                                                ForEach(orderedFolder, id: \.self.id){ folder in
-                                                    Button(action: {
-                                                        chosenFolder = folder
-                                                    }) {
-                                                        HStack {
-                                                            if chosenFolder == folder {
-                                                                Image(systemName: "checkmark")
-                                                            } else {
-                                                                Image(systemName: "checkmark").hidden()
-                                                            }
-                                                            
-                                                            Text("\(folder.name)")
-                                                            Spacer()
-                                                            HStack {
-                                                                if chosenFolder == folder {
-                                                                    Image(systemName: "checkmark")
-                                                                } else {
-                                                                    Image(systemName: "checkmark").hidden()
-                                                                }
-                                                            }
-                                                            .frame(width: 30)
+                                        Menu {
+                                            ForEach(orderedFolder, id: \.self.id){ folder in
+                                                Button {
+                                                    chosenFolder = folder
+                                                } label : {
+                                                    HStack {
+                                                        if chosenFolder == folder {
+                                                            Image(systemName: "checkmark")
+                                                        } else {
+                                                            Image(systemName: "checkmark").hidden()
                                                         }
+                                                        Text("\(folder.name)")
+                                                        Spacer()
                                                     }
                                                 }
-                                            } label: {
+                                            }
+                                        } label: {
+                                            Group {
+                                                Circle()
+                                                    .frame(width: 12, height: 12)
+                                                    .foregroundStyle(chosenFolderColor)
                                                 Text("\(chosenFolderName)")
                                                 //                                Text(chosenFolder.name)
                                                 Image(systemName: "chevron.up.chevron.down")
                                                     .resizable()
                                                     .frame(width: 10, height: 15)
                                             }
-                                            
-                                            
                                         }
                                     }
                                     
@@ -208,7 +196,7 @@ struct MakeTodoView: View {
                                     Button {
                                         alarmisActive.toggle()
                                     } label: {
-                                        HStack{
+                                        HStack {
                                             Text("알람")
                                             Spacer()
                                             Text(alarmDataisEmpty ?? true ? "없음" : Date().makeAlarmDate(alarmData: contentAlarm ?? Date()))

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -67,7 +67,7 @@ struct MakeTodoView: View {
     @State private var selectedItems = [PhotosPickerItem]()
     @State private var selectedIndexs: Int = 0
     
-    //알람 설정 관련
+    //알림 설정 관련
     @State private var showAlert = false
     @State private var alertMessage = ""
     
@@ -201,7 +201,7 @@ struct MakeTodoView: View {
                                     alarmisActive.toggle()
                                 } label: {
                                     HStack {
-                                        Text("알람")
+                                        Text("알림")
                                         Spacer()
                                         Text(alarmDataisEmpty ?? true ? "없음" : Date().makeAlarmDate(alarmData: contentAlarm ?? Date()))
                                     }
@@ -389,9 +389,9 @@ struct MakeTodoView: View {
     
     func saveTodoItem() {
         var id: String = ""
-        // 알람 데이터가 있으면
+        // 알림 데이터가 있으면
         
-        // MARK: 생성 시 만들어 지는 곳 -> 알람 데이터 삭제 필요 없음
+        // MARK: 생성 시 만들어 지는 곳 -> 알림 데이터 삭제 필요 없음
         if alarmDataisEmpty != nil && !alarmDataisEmpty! {
             // alarmDataisEmpty == false일 경우 알림을 설정하는 것이기 때문에 데이터가 무조건 있다고 봄
             let calendar = Calendar.current
@@ -401,7 +401,7 @@ struct MakeTodoView: View {
             let hour = calendar.component(.hour, from: contentAlarm!)
             let minute = calendar.component(.minute, from: contentAlarm!)
             
-            // Notification 알람 생성 및 id Todo에 저장하기
+            // Notification 알림 생성 및 id Todo에 저장하기
             id = manager.makeTodoNotification(year: year, month: month, day: day, hour: hour, minute: minute)
         }
         

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -158,6 +158,7 @@ struct MakeTodoView: View {
                                 .fill(Color.paleGray) // 배경색 설정
                             List {
                                 Section{
+                                    // 폴더 선택 행
                                     HStack{
                                         Text("폴더")
                                         Spacer()
@@ -202,6 +203,8 @@ struct MakeTodoView: View {
                                             
                                         }
                                     }
+                                    
+                                    // 알림 생성 행
                                     Button {
                                         alarmisActive.toggle()
                                     } label: {
@@ -243,7 +246,7 @@ struct MakeTodoView: View {
                                         .presentationDetents([.height(CGFloat(300))])
                                     })
                                     
-                                    
+                                    // 메모 생성 행
                                     Button(action: {
                                         memoisActive.toggle()
                                         newMemo = memo ?? ""

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -37,6 +37,7 @@ struct MakeTodoView: View {
     @State private var cameraVM = CameraViewModel.shared
     @Binding var chosenFolder: Folder?
     var startViewType: startViewType
+    var onSave: (() -> Void)? = nil
     
     // 내부 컨텐츠
     @Binding var contentAlarm: Date?
@@ -344,20 +345,45 @@ struct MakeTodoView: View {
             // 이러한 이유로, 원치 않은 사이드 이팩트를 막기 위해 카메라 시트를 닫을 때에 반드시 home을 false로 바꿔줘야 함
             home = false
         }
-        .toolbar(startViewType == .edit ? .hidden : .visible)
         .toolbar {
-            // 완료 및 저장 버튼
-            if #available(iOS 26.0, *) {
-                Button(role: .confirm) {
-                    saveTodoItem()
-                } label : {
-                    Text("test")
+            if (startViewType == .edit) {
+                ToolbarItem(placement: .topBarLeading) {
+                    if #available(iOS 26.0, *) {
+                        Button(role: .close) {
+                            dismiss()
+                        }
+                    } else {
+                        Button {
+                            dismiss()
+                        } label: {
+                            Text("취소")
+                        }
+                    }
                 }
-            } else {
-                Button {
-                    saveTodoItem()
-                } label: {
-                    Text("저장")
+            }
+            
+            // 완료 및 저장 버튼
+            ToolbarItem {
+                if #available(iOS 26.0, *) {
+                    Button(role: .confirm) {
+                        // .edit 모드일 때는 콜백 함수 실행
+                        if startViewType == .edit {
+                            onSave?()
+                            return
+                        }
+                        createTodoItem()
+                    }
+                } else {
+                    Button {
+                        // .edit 모드일 때는 콜백 함수 실행
+                        if startViewType == .edit {
+                            onSave?()
+                            return
+                        }
+                        createTodoItem()
+                    } label: {
+                        Text("저장")
+                    }
                 }
             }
         }
@@ -395,7 +421,7 @@ struct MakeTodoView: View {
         }
     }
     
-    func saveTodoItem() {
+    func createTodoItem() {
         var id: String = ""
         // 알림 데이터가 있으면
         
@@ -487,6 +513,6 @@ extension Binding {
     @Previewable @State var alarmDataisEmpty: Bool = true
     @Previewable @State var home: Bool? = false
     @Previewable @State var alarmID = ""
-    return MakeTodoView(chosenFolder: $chosenFolder, startViewType: .camera, contentAlarm: .constant(Date()), alarmID: .constant(""), alarmDataisEmpty: .constant(true), memo: .constant(""), home: .constant(true))
+    return MakeTodoView(chosenFolder: $chosenFolder, startViewType: .camera, onSave: nil, contentAlarm: .constant(Date()), alarmID: .constant(""), alarmDataisEmpty: .constant(true), memo: .constant(""), home: .constant(true))
     
 }

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -154,143 +154,145 @@ struct MakeTodoView: View {
                     }
                     VStack {
                         ZStack{
-                            RoundedRectangle(cornerRadius: 20) // 원하는 radius 값
-                                .fill(Color.paleGray) // 배경색 설정
-                            List {
-                                Section{
-                                    // 폴더 선택 행
-                                    HStack {
-                                        Text("폴더")
-                                        Spacer()
-                                        Menu {
-                                            ForEach(orderedFolder, id: \.self.id){ folder in
-                                                Button {
-                                                    chosenFolder = folder
-                                                } label : {
-                                                    HStack {
-                                                        if chosenFolder == folder {
-                                                            Image(systemName: "checkmark")
-                                                        } else {
-                                                            Image(systemName: "checkmark").hidden()
-                                                        }
-                                                        Text("\(folder.name)")
-                                                        Spacer()
+                            RoundedRectangle(cornerRadius: 20)
+                                .fill(Color.paleGray)
+                            VStack(spacing: 0) {
+                                // 폴더 선택 행
+                                HStack {
+                                    Text("폴더")
+                                    Spacer()
+                                    Menu {
+                                        ForEach(orderedFolder, id: \.self.id){ folder in
+                                            Button {
+                                                chosenFolder = folder
+                                            } label : {
+                                                HStack {
+                                                    if chosenFolder == folder {
+                                                        Image(systemName: "checkmark")
+                                                    } else {
+                                                        Image(systemName: "checkmark").hidden()
                                                     }
+                                                    Text("\(folder.name)")
+                                                    Spacer()
                                                 }
                                             }
-                                        } label: {
-                                            Group {
-                                                Circle()
-                                                    .frame(width: 12, height: 12)
-                                                    .foregroundStyle(chosenFolderColor)
-                                                Text("\(chosenFolderName)")
-                                                //                                Text(chosenFolder.name)
-                                                Image(systemName: "chevron.up.chevron.down")
-                                                    .resizable()
-                                                    .frame(width: 10, height: 15)
-                                            }
                                         }
-                                    }
-                                    
-                                    // 알림 생성 행
-                                    Button {
-                                        alarmisActive.toggle()
                                     } label: {
-                                        HStack {
-                                            Text("알람")
-                                            Spacer()
-                                            Text(alarmDataisEmpty ?? true ? "없음" : Date().makeAlarmDate(alarmData: contentAlarm ?? Date()))
+                                        Group {
+                                            Circle()
+                                                .frame(width: 12, height: 12)
+                                                .foregroundStyle(chosenFolderColor)
+                                            Text("\(chosenFolderName)")
+                                            Image(systemName: "chevron.up.chevron.down")
+                                                .resizable()
+                                                .frame(width: 10, height: 15)
                                         }
                                     }
-                                    .sheet(isPresented: $alarmisActive, content: {
-                                        VStack{
-                                            HStack{
-                                                Button(action: {
-                                                    contentAlarm = Date()
-                                                    alarmDataisEmpty = true
-                                                    alarmisActive.toggle()
-                                                }, label: {
-                                                    Text("리셋")
-                                                })
-                                                Spacer()
-                                                Button(action: {
-                                                    alarmDataisEmpty = false
-                                                    alarmisActive.toggle()
-                                                }, label: {
-                                                    Text("완료")
-                                                })
-                                            }
-                                            
-                                            DatePicker(
-                                                "Select Date",
-                                                selection: $contentAlarm.withDefault(Date()),
-                                                in: Date()...,
-                                                displayedComponents: [.date, .hourAndMinute]
-                                            )
-                                            .labelsHidden()
-                                            .datePickerStyle(.wheel)
-                                        }
-                                        .padding()
-                                        .presentationDetents([.height(CGFloat(300))])
-                                    })
-                                    
-                                    // 메모 생성 행
-                                    Button(action: {
-                                        memoisActive.toggle()
-                                        newMemo = memo ?? ""
-                                    }, label: {
-                                        HStack{
-                                            //                                        Image(systemName: "pencil")
-                                            //                                            .resizable()
-                                            //                                            .frame(width: 15, height: 15)
-                                            Text("메모")
-                                            Spacer()
-                                            if let memo = memo {
-                                                Text(memo.count > 5 ? String("\(memo.prefix(5))...") : memo)
-                                                    .lineLimit(1)
-                                                    .truncationMode(.tail)
-                                            }
-                                            
-                                            Image(systemName: "chevron.right")
-                                                .resizable()
-                                                .frame(width: 8, height: 12)
-                                        }
-                                    })
-                                    .sheet(isPresented: $memoisActive, content: {
-                                        VStack{
-                                            HStack{
-                                                Spacer()
-                                                Button(action: {
-                                                    memoisActive.toggle()
-                                                    memo = newMemo
-                                                }, label: {
-                                                    Text("완료")
-                                                })
-                                            }
-                                            
-                                            VStack{
-                                                TextField("메모를 입력해주세요.", text: $newMemo, axis: .vertical	)
-                                            }.frame(height: 100, alignment: .top)
-                                            
-                                            Spacer()
-                                        }
-                                        .padding()
-                                        .presentationDetents([.height(CGFloat(200))])
-                                    })
                                 }
-                                .listRowBackground(Color.clear)
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, 12)
                                 .foregroundStyle(Color.black)
+                                
+                                Divider()
+                                    .padding(.horizontal, 20)
+                                
+                                // 알림 생성 행
+                                Button {
+                                    alarmisActive.toggle()
+                                } label: {
+                                    HStack {
+                                        Text("알람")
+                                        Spacer()
+                                        Text(alarmDataisEmpty ?? true ? "없음" : Date().makeAlarmDate(alarmData: contentAlarm ?? Date()))
+                                    }
+                                    .padding(.horizontal, 20)
+                                    .padding(.vertical, 12)
+                                    .foregroundStyle(Color.black)
+                                }
+                                .sheet(isPresented: $alarmisActive, content: {
+                                    VStack{
+                                        HStack{
+                                            Button(action: {
+                                                contentAlarm = Date()
+                                                alarmDataisEmpty = true
+                                                alarmisActive.toggle()
+                                            }, label: {
+                                                Text("리셋")
+                                            })
+                                            Spacer()
+                                            Button(action: {
+                                                alarmDataisEmpty = false
+                                                alarmisActive.toggle()
+                                            }, label: {
+                                                Text("완료")
+                                            })
+                                        }
+                                        
+                                        DatePicker(
+                                            "Select Date",
+                                            selection: $contentAlarm.withDefault(Date()),
+                                            in: Date()...,
+                                            displayedComponents: [.date, .hourAndMinute]
+                                        )
+                                        .labelsHidden()
+                                        .datePickerStyle(.wheel)
+                                    }
+                                    .padding()
+                                    .presentationDetents([.height(CGFloat(300))])
+                                })
+                                
+                                Divider()
+                                    .padding(.horizontal, 20)
+                                
+                                // 메모 생성 행
+                                Button(action: {
+                                    memoisActive.toggle()
+                                    newMemo = memo ?? ""
+                                }, label: {
+                                    HStack{
+                                        Text("메모")
+                                        Spacer()
+                                        if let memo = memo {
+                                            Text(memo.count > 5 ? String("\(memo.prefix(5))...") : memo)
+                                                .lineLimit(1)
+                                                .truncationMode(.tail)
+                                        }
+                                        
+                                        Image(systemName: "chevron.right")
+                                            .resizable()
+                                            .frame(width: 8, height: 12)
+                                    }
+                                    .padding(.horizontal, 20)
+                                    .padding(.vertical, 12)
+                                    .foregroundStyle(Color.black)
+                                })
+                                .sheet(isPresented: $memoisActive, content: {
+                                    VStack{
+                                        HStack{
+                                            Spacer()
+                                            Button(action: {
+                                                memoisActive.toggle()
+                                                memo = newMemo
+                                            }, label: {
+                                                Text("완료")
+                                            })
+                                        }
+                                        
+                                        VStack{
+                                            TextField("메모를 입력해주세요.", text: $newMemo, axis: .vertical	)
+                                        }.frame(height: 100, alignment: .top)
+                                        
+                                        Spacer()
+                                    }
+                                    .padding()
+                                    .presentationDetents([.height(CGFloat(200))])
+                                })
                             }
-                            .padding(.leading, -16)
-                            .padding(.top, -34)
-                            .background(Color.clear) // List의 배경색을 투명하게 설정
-                            .scrollContentBackground(.hidden)
-                            .scrollDisabled(true)
-                            .frame(minHeight: 132)
+                            .padding(.vertical, 8)
                         }
-                        .clipShape(RoundedRectangle(cornerRadius: 20)) // 모서리 둥글게
+                        .clipShape(RoundedRectangle(cornerRadius: 20))
                     }
-                    .frame(width: 350, height: 132)
+                    .frame(width: 350)
                 }
                 .padding(.horizontal, 20)
                 if isZoomViewPresented {

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -63,7 +63,7 @@ struct TodoGridView: View {
     @State private var isCameraSheetOn: Bool = false
     @State private var isCameraNavigate: Bool = false
     
-    @Query private var compositeTodos: [Todo] 
+    @Query private var compositeTodos: [Todo]
     
     private var todos: [Todo] {
         switch viewType {
@@ -216,8 +216,16 @@ struct TodoGridView: View {
                             .presentationDragIndicator(.visible)
                             .toolbar {
                                 ToolbarItem(placement: .navigationBarLeading) {
-                                    Button("취소") {
-                                        isDoneSelecting = false
+                                    if #available(iOS 26.0, *) {
+                                        Button(role: .close) {
+                                            isDoneSelecting = false
+                                        }
+                                    } else {
+                                        Button {
+                                            isDoneSelecting = false
+                                        } label: {
+                                            Text("취소")
+                                        }
                                     }
                                 }
                             }

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -160,9 +160,6 @@ struct TodoGridView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            if viewType == .main {
-                customNavBar
-            }
             ZStack {
                 Color("gray/gray-200").ignoresSafeArea()
                 VStack {
@@ -198,7 +195,6 @@ struct TodoGridView: View {
         }
         .photosPicker(isPresented: $showingImagePicker, selection: $selectedItems,  maxSelectionCount: 10, matching: .not(.videos))
         .onChange(of: selectedItems, loadImage)
-        .navigationBarHidden( viewType == .main ? true : false)
         .sheet(isPresented: $isCameraNavigate, content: {
             NavigationStack{
                 CameraView(chosenFolder: currentFolder, isCameraSheetOn: $isCameraSheetOn, home: $home)
@@ -261,81 +257,48 @@ struct TodoGridView: View {
                         }
                     }
             }
+            
+            if viewType == .main {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Menu {
+                        Button {
+                            alarmSetting.toggle()
+                        } label: {
+                            HStack {
+                                Text("정기 알람 설정")
+                                Image(systemName: "alarm")
+                            }
+                        }
+                        
+                        Button {
+                            
+                        } label: {
+                            HStack {
+                                Text("도움말")
+                                Image(systemName: "info.circle")
+                            }
+                        }
+                        
+                        Button {
+                            
+                        } label: {
+                            HStack {
+                                Text("팀소개")
+                                Image(systemName: "leaf")
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                    }
+                }
+            }
         }
         .environment(\.editMode, $editMode)
-    }
-    
-    private var customNavBar: some View {
-        HStack(spacing: 0) {
-            Spacer()
-            
-            //편집모드에서 다중선택된 아이템 삭제
-            Button(action: editMode == .active ? deleteSelectedTodos : toggleAddOptions) {
-                if editMode == .active {
-                    Image(systemName: "trash")
-                        .font(.title2)
-                        .foregroundStyle(Color("green/green-700"))
-                } else {
-                    Image(systemName: "plus")
-                        .font(.title2)
-                        .foregroundStyle(Color("green/green-700"))
-                }
-            }
-            .frame(width: 44)
-            
-            EditButton()
-                .frame(width: 44)
-                .onChange(of: editMode) { _, newEditMode in
-                    //편집모드 해제시 선택정보 삭제
-                    if newEditMode == .inactive {
-                        selectedTodos.removeAll()
-                    }
-                }
-            
-            Menu {
-                Button {
-                    alarmSetting.toggle()
-                } label: {
-                    HStack {
-                        Text("정기 알람 설정")
-                        Image(systemName: "alarm")
-                    }
-                }
-                
-                Button {
-                    
-                } label: {
-                    HStack {
-                        Text("도움말")
-                        Image(systemName: "info.circle")
-                    }
-                }
-                
-                Button {
-                    
-                } label: {
-                    HStack {
-                        Text("팀소개")
-                        Image(systemName: "leaf")
-                    }
-                }
-                
-            } label: {
-                Image(systemName: "ellipsis.circle")
-                    .font(.title2)
-                    .foregroundStyle(Color("green/green-700"))
-            }
-            .frame(width: 44)
-        }
         .sheet(isPresented: $alarmSetting, content: {
             AlarmSettingView()
                 .presentationDetents([.height(CGFloat(450))])
                 .presentationDragIndicator(.visible)
         })
-        .frame(height: 44)
-        .padding(.horizontal, 20)
-        .padding(.top, 5)
-        .environment(\.editMode, $editMode)
     }
     
     private var sortMenu: some View {

--- a/PhotoTodo/TodoItemView.swift
+++ b/PhotoTodo/TodoItemView.swift
@@ -81,24 +81,8 @@ struct TodoItemView: View {
             .sheet(isPresented: $editTodoisActive, content: {
                 NavigationStack{
                     VStack{
-                        HStack{
-                            // 각 아이템을 클릭하면 나오는 디테일 뷰에서 뒤로가기를 할 때 사용되는 버튼
-                            Button {
-                                editTodoisActive.toggle()
-                            } label: {
-                                Text("취소")
-                            }
-                            Spacer()
-                            // 저장 버튼
-                            Button {
-                                saveTodoItem()
-                            } label: {
-                                Text("저장")
-                            }
-                        }
-                        .padding()
                         ScrollView{
-                            MakeTodoView(chosenFolder: $chosenFolder, startViewType: .edit, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
+                            MakeTodoView(chosenFolder: $chosenFolder, startViewType: .edit, onSave: saveTodoItem, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
                                 .presentationDragIndicator(.visible)
                         }
                     }


### PR DESCRIPTION
## 작업내용
- iOS26의 툴바의 버튼에 적용되는 리퀴드 글래스 디자인(`.close` `.confirm` 등의 `role` 적용)이 메인화면과 `MakeTodoView`에 적용되도록 작업하였습니다.
- `MakeTodoView`에 있던 `saveTodoItem` 함수를 `createTodoItem` 함수로 변경하고, `TodoItemView`을 Tap하여 기존의 Todo에 대한 수정이 진행될 경우 callback 함수`saveTodoItem`이 호출되도록 수정하였습니다. 

## 메인화면 비교
|iOS 26 이전 | iOS 26 이후 |
| --- | --- |
|<img src="https://github.com/user-attachments/assets/505dba63-e0e2-4873-b6e1-f814980ded1d" />| <img src = "https://github.com/user-attachments/assets/14012abe-39ba-401a-b94d-7c314a9e2441" >|
|<img src = "https://github.com/user-attachments/assets/acbc269d-b223-4ee1-aad5-57cc40f92f33"> | <img src = "https://github.com/user-attachments/assets/9dd0d224-d795-404b-895d-46428330e01c"> |

## MakeTodoView 비교
|iOS 26 이전 | iOS 26 이후 |
| --- | --- |
|<img src = "https://github.com/user-attachments/assets/713f584c-6b90-4837-9177-e42e6eca8f02">| <img src = "https://github.com/user-attachments/assets/cb41505c-17ab-48f7-85a7-b445d1850f91"> |


