### PR TITLE
DeleteRule 추가 V3 마이그레이션

### DIFF
--- a/PhotoTodo.xcodeproj/project.pbxproj
+++ b/PhotoTodo.xcodeproj/project.pbxproj
@@ -562,7 +562,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -603,7 +603,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PhotoTodo.xcodeproj/project.pbxproj
+++ b/PhotoTodo.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		1AB52CFB2EE56014001237D1 /* PhotoTodoSchemaV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB52CF92EE56010001237D1 /* PhotoTodoSchemaV2.swift */; };
 		1AB52CFD2EE56292001237D1 /* PhotoTodoMigrationPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB52CFC2EE56280001237D1 /* PhotoTodoMigrationPlan.swift */; };
 		1AB52CFE2EE56292001237D1 /* PhotoTodoMigrationPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB52CFC2EE56280001237D1 /* PhotoTodoMigrationPlan.swift */; };
+		1ABA97282F17BB80004DF3B7 /* PhotoTodoSchemaV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABA97272F17BB7A004DF3B7 /* PhotoTodoSchemaV3.swift */; };
+		1ABA97292F17BB80004DF3B7 /* PhotoTodoSchemaV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABA97272F17BB7A004DF3B7 /* PhotoTodoSchemaV3.swift */; };
 		1ACE61902D92E10800090C27 /* FolderManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A27017D2D62C35900DA8892 /* FolderManager.swift */; };
 		1ACE61912D92E2D200090C27 /* FolderCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E5C832C5B573400BAFD13 /* FolderCarouselView.swift */; };
 		1ACE61922D92E32400090C27 /* FolderEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F46B28A2C5C7E2100556646 /* FolderEditView.swift */; };
@@ -101,6 +103,7 @@
 		1A8584022D435EFB00092B0E /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
 		1AB52CF92EE56010001237D1 /* PhotoTodoSchemaV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTodoSchemaV2.swift; sourceTree = "<group>"; };
 		1AB52CFC2EE56280001237D1 /* PhotoTodoMigrationPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTodoMigrationPlan.swift; sourceTree = "<group>"; };
+		1ABA97272F17BB7A004DF3B7 /* PhotoTodoSchemaV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTodoSchemaV3.swift; sourceTree = "<group>"; };
 		1ACE61942D92F0EF00090C27 /* PhotoTodoRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PhotoTodoRelease.entitlements; sourceTree = "<group>"; };
 		1AFB12A12C77243A00952121 /* ShareImage.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareImage.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		1AFB12A32C77243A00952121 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
@@ -152,6 +155,7 @@
 			children = (
 				1AFB12B02C77245500952121 /* PhotoTodoSchemaV1.swift */,
 				1AB52CF92EE56010001237D1 /* PhotoTodoSchemaV2.swift */,
+				1ABA97272F17BB7A004DF3B7 /* PhotoTodoSchemaV3.swift */,
 				1AB52CFC2EE56280001237D1 /* PhotoTodoMigrationPlan.swift */,
 			);
 			path = Models;
@@ -365,6 +369,7 @@
 				1A0D96832C5A14F300784CBA /* CameraViewModel.swift in Sources */,
 				1A0D96852C5A150D00784CBA /* CameraPreview.swift in Sources */,
 				1A2778DE2C56395900A02C7E /* PhotoTodoApp.swift in Sources */,
+				1ABA97292F17BB80004DF3B7 /* PhotoTodoSchemaV3.swift in Sources */,
 				1A2778F42C57415900A02C7E /* CameraView.swift in Sources */,
 				1A27017E2D62C35C00DA8892 /* FolderManager.swift in Sources */,
 				131501CD2C61FCA000AAA4A2 /* AlarmSettingView.swift in Sources */,
@@ -380,6 +385,7 @@
 				1ACE61902D92E10800090C27 /* FolderManager.swift in Sources */,
 				1AFB12B22C77245500952121 /* PhotoTodoSchemaV1.swift in Sources */,
 				1ACE61922D92E32400090C27 /* FolderEditView.swift in Sources */,
+				1ABA97282F17BB80004DF3B7 /* PhotoTodoSchemaV3.swift in Sources */,
 				1AFB12A42C77243A00952121 /* ShareViewController.swift in Sources */,
 				1AB52CFE2EE56292001237D1 /* PhotoTodoMigrationPlan.swift in Sources */,
 				1AB52CFA2EE56014001237D1 /* PhotoTodoSchemaV2.swift in Sources */,

--- a/PhotoTodo/Models/PhotoTodoMigrationPlan.swift
+++ b/PhotoTodo/Models/PhotoTodoMigrationPlan.swift
@@ -10,11 +10,11 @@ import SwiftUI
 
 enum PhotoTodoMigrationPlan: SchemaMigrationPlan {
     static var schemas: [any VersionedSchema.Type] {
-        [PhotoTodoSchemaV1.self, PhotoTodoSchemaV2.self]
+        [PhotoTodoSchemaV1.self, PhotoTodoSchemaV2.self, PhotoTodoSchemaV3.self]
     }
     
     static var stages: [MigrationStage] {
-        [migrateV1toV2]
+        [migrateV1toV2, migrateV2toV3]
     }
     static var rawImageBackup: [UUID: [Data]] = [:]
     
@@ -40,5 +40,10 @@ enum PhotoTodoMigrationPlan: SchemaMigrationPlan {
             try? context.save()
             rawImageBackup.removeAll()
         }
+    )
+    
+    static let migrateV2toV3 = MigrationStage.lightweight(
+        fromVersion: PhotoTodoSchemaV2.self,
+        toVersion: PhotoTodoSchemaV3.self
     )
 }

--- a/PhotoTodo/Models/PhotoTodoSchemaV3.swift
+++ b/PhotoTodo/Models/PhotoTodoSchemaV3.swift
@@ -1,15 +1,16 @@
 //
-//  PhotoTodoSchemaV2.swift
+//  PhotoTodoSchemaV3.swift
 //  PhotoTodo
 //
-//  Created by Lyosha's MacBook   on 12/7/25.
+//  Created by Lyosha's MacBook   on 1/14/26.
 //
+
 import Foundation
 import SwiftData
 import SwiftUI
 
-enum PhotoTodoSchemaV2: VersionedSchema {
-    static var versionIdentifier: Schema.Version { Schema.Version(2, 0, 0)}
+enum PhotoTodoSchemaV3: VersionedSchema {
+    static var versionIdentifier: Schema.Version { Schema.Version(3, 0, 0)}
     static var models: [any PersistentModel.Type] {
         [Folder.self, Todo.self, Photo.self, Options.self, FolderOrder.self]
     }
@@ -33,7 +34,7 @@ enum PhotoTodoSchemaV2: VersionedSchema {
     final class Todo {
         var folder: Folder?
         @Attribute(.unique) var id: UUID
-        @Attribute var images: [Photo]
+        @Relationship(deleteRule:.cascade) var images: [Photo]
         var createdAt: Date
         @Relationship(inverse: \Options.todo) var options: Options
         var isDone: Bool
@@ -84,3 +85,11 @@ enum PhotoTodoSchemaV2: VersionedSchema {
         }
     }
 }
+
+typealias Folder = PhotoTodoSchemaV3.Folder
+typealias Todo = PhotoTodoSchemaV3.Todo
+typealias Photo = PhotoTodoSchemaV3.Photo
+typealias Options = PhotoTodoSchemaV3.Options
+typealias FolderOrder = PhotoTodoSchemaV3.FolderOrder
+
+


### PR DESCRIPTION
## 작업사항
- Todo가 삭제될 때 연관된 사진들이 함께 삭제될 수 있도록 deleteRule을 모델에 추가하였고, 마이그레이션플랜을 작성하였습니다. 

```swift
@Model
    final class Todo {
        @Relationship(deleteRule:.cascade) var images: [Photo]
...
    }
```