### PR TITLE
메모 생성 에러 수정, iOS26 디자인 반영

### DIFF
--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -209,6 +209,7 @@ struct MakeTodoView: View {
                                     .frame(height: 44)
                                     .padding(.horizontal, 20)
                                     .foregroundStyle(Color.black)
+                                    .contentShape(Rectangle())
                                 }
                                 .buttonStyle(.plain)
                                 .sheet(isPresented: $alarmisActive, content: {
@@ -267,6 +268,7 @@ struct MakeTodoView: View {
                                     .frame(height: 44)
                                     .padding(.horizontal, 20)
                                     .foregroundStyle(Color.black)
+                                    .contentShape(Rectangle())
                                 }
                                 .buttonStyle(.plain)
                                 .sheet(isPresented: $memoisActive, content: {

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -247,10 +247,10 @@ struct MakeTodoView: View {
                                     .padding(.horizontal, 20)
                                 
                                 // 메모 생성 행
-                                Button(action: {
+                                Button {
                                     memoisActive.toggle()
                                     newMemo = memo ?? ""
-                                }, label: {
+                                } label: {
                                     HStack{
                                         Text("메모")
                                         Spacer()
@@ -267,28 +267,39 @@ struct MakeTodoView: View {
                                     .frame(height: 44)
                                     .padding(.horizontal, 20)
                                     .foregroundStyle(Color.black)
-                                })
+                                }
                                 .buttonStyle(.plain)
                                 .sheet(isPresented: $memoisActive, content: {
-                                    VStack{
-                                        HStack{
+                                    NavigationStack {
+                                        VStack(alignment: .leading) {
+                                            TextField("메모를 입력해주세요.", text: $newMemo, axis: .vertical)
+                                                .textFieldStyle(.plain)
+                                                .frame(maxHeight: .infinity, alignment: .top)
+                                            
                                             Spacer()
-                                            Button(action: {
-                                                memoisActive.toggle()
-                                                memo = newMemo
-                                            }, label: {
-                                                Text("완료")
-                                            })
                                         }
-                                        
-                                        VStack{
-                                            TextField("메모를 입력해주세요.", text: $newMemo, axis: .vertical	)
-                                        }.frame(height: 100, alignment: .top)
-                                        
-                                        Spacer()
+                                        .padding()
+                                        .navigationTitle("메모")
+                                        .navigationBarTitleDisplayMode(.inline)
+                                        .toolbar {
+                                            ToolbarItem(placement: .topBarTrailing) {
+                                                if #available(iOS 26.0, *) {
+                                                    Button(role: .confirm) {
+                                                        memoisActive.toggle()
+                                                        memo = newMemo
+                                                    }
+                                                } else {
+                                                    Button {
+                                                        memoisActive.toggle()
+                                                        memo = newMemo
+                                                    } label: {
+                                                        Text("완료")
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        .presentationDetents([.height(CGFloat(250))])
                                     }
-                                    .padding()
-                                    .presentationDetents([.height(CGFloat(200))])
                                 })
                             }
                         }

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -212,7 +212,7 @@ struct TodoGridView: View {
             NavigationStack{
                 VStack{
                     ScrollView{
-                        MakeTodoView(chosenFolder: $currentFolder, startViewType: .camera, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
+                        MakeTodoView(chosenFolder: $currentFolder, startViewType: viewType == .main ? .gridMain : .gridSingleFolder, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
                             .presentationDragIndicator(.visible)
                             .toolbar {
                                 ToolbarItem(placement: .navigationBarLeading) {


### PR DESCRIPTION
## 작업내용
### 메모 오류 수정
- `TodoItem`에 메모를 넣어 생성한 이후 새로 생성할 때 이전 메모가 남아있는 오류가 있었습니다. `TodoGridView`에서 `sheet`를 통해 `MakeTodoView`를 띄울 때 `StartViewType`을 잘못 넣어주고 있어서 생긴 오류였기 때문에, 옳게 들어가도록 처리해주었습니다.

#### 이전 코드
```swift
MakeTodoView(chosenFolder: $currentFolder, startViewType: viewType = .camera, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
```

#### 수정된 코드
```swift
MakeTodoView(chosenFolder: $currentFolder, startViewType: viewType == .main ? .gridMain : .gridSingleFolder, contentAlarm: $contentAlarm, alarmID: $alarmID, alarmDataisEmpty: $alarmDataisEmpty, memo: $memo, home: $home)
```

### iOS26 디자인 적용
- 메모 시트에도 iOS26 리퀴드 글래스 디자인이 적용되도록 수정하였습니다.

## 비교
|before|after|
|---|---|
|<video src = "https://github.com/user-attachments/assets/50d9991e-619f-43b3-9a7d-ea22f6509696">|<video src = "https://github.com/user-attachments/assets/4ec77c63-79bb-4b07-a03c-eb5494306771">|

|iOS26 이전|iOS26 이후|
|---|---|
|<img src = "https://github.com/user-attachments/assets/00ea938a-170a-4e16-b968-099afea84373"> |<img src = "https://github.com/user-attachments/assets/80d008cf-46e7-48d1-b6a2-1ac9076efd2a">|
