### PR TITLE
fix: migration 에러 해결

### DIFF
--- a/PhotoTodo/Models/PhotoTodoSchemaV1.swift
+++ b/PhotoTodo/Models/PhotoTodoSchemaV1.swift
@@ -5,7 +5,7 @@ import SwiftUI
 enum PhotoTodoSchemaV1: VersionedSchema {
     static var versionIdentifier: Schema.Version { Schema.Version(1, 0, 0)}
     static var models: [any PersistentModel.Type] {
-        [Folder.self, Todo.self, Options.self, FolderOrder.self]
+        [PhotoTodoSchemaV1.Folder.self, PhotoTodoSchemaV1.Todo.self, PhotoTodoSchemaV1.Options.self, PhotoTodoSchemaV1.FolderOrder.self]
     }
     
     @Model

--- a/PhotoTodo/Models/PhotoTodoSchemaV2.swift
+++ b/PhotoTodo/Models/PhotoTodoSchemaV2.swift
@@ -11,7 +11,7 @@ import SwiftUI
 enum PhotoTodoSchemaV2: VersionedSchema {
     static var versionIdentifier: Schema.Version { Schema.Version(2, 0, 0)}
     static var models: [any PersistentModel.Type] {
-        [Folder.self, Todo.self, Photo.self, Options.self, FolderOrder.self]
+        [PhotoTodoSchemaV2.Folder.self, PhotoTodoSchemaV2.Todo.self, PhotoTodoSchemaV2.Photo.self, PhotoTodoSchemaV2.Options.self, PhotoTodoSchemaV2.FolderOrder.self]
     }
     
     @Model

--- a/PhotoTodo/Models/PhotoTodoSchemaV3.swift
+++ b/PhotoTodo/Models/PhotoTodoSchemaV3.swift
@@ -40,6 +40,8 @@ enum PhotoTodoSchemaV3: VersionedSchema {
         var isDone: Bool
         var isDoneAt: Date?
         
+        private var schemaPatch_v3: Int?
+        
         init(folder: Folder? = nil, id: UUID, images: [Photo], createdAt: Date, options: Options, isDone: Bool, isDoneAt: Date? = nil) {
             self.folder = folder
             self.id = id


### PR DESCRIPTION
- #136 
- iOS 26 이하 버전에서 마이그레이션 에러가 났습니다. 
```
"*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Duplicate version checksums across stages detected.'

terminating due to uncaught exception of type NSException

CoreSimulator 1051.9.4 - Device: iPhone 16 Pro (3A3DFE71-782C-42A9-BB05-8EF644059A2B) - Runtime: iOS 18.2 (22C150) - DeviceType: iPhone 16 Pro"
```
-V2 todo의 images의 @Attribute 가 @Relationship(deleteRule: .cascade)으로 변경되었지만 이것이 구조적 변화로 인식되지 못해 일어나는 에러였습니다. 실제로 사용되지 않는 옵셔널 밸류를 todo에 넣어주면서 이를 우회하였습니다. 