### PR TITLE
알림 생성 경험 개선

### DIFF
--- a/PhotoTodo/AlarmSettingView.swift
+++ b/PhotoTodo/AlarmSettingView.swift
@@ -44,7 +44,7 @@ struct AlarmSettingView: View {
                 .padding(EdgeInsets(top: 0, leading: 20, bottom: 11, trailing: 20))
                 
                 VStack(alignment: .leading){
-                    Text("정기 알람 설정")
+                    Text("정기 알림 설정")
                         .font(.title2.bold())
                         .padding(.bottom, 3)
                     Text("지정한 요일과 시간에 알림을 보내드립니다.")

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -41,6 +41,7 @@ struct MakeTodoView: View {
     
     // 내부 컨텐츠
     @Binding var contentAlarm: Date?
+    @State var selectedAlarm: Date?
     @Binding var alarmID: String?
     @State private var folderMenuisActive: Bool = false
     @State private var alarmisActive: Bool = false
@@ -200,6 +201,7 @@ struct MakeTodoView: View {
                                 // 알림 생성 행
                                 Button {
                                     alarmisActive.toggle()
+                                    selectedAlarm = contentAlarm
                                 } label: {
                                     HStack {
                                         Text("알림")
@@ -217,7 +219,7 @@ struct MakeTodoView: View {
                                         VStack {
                                             DatePicker(
                                                 "Select Date",
-                                                selection: $contentAlarm.withDefault(Date()),
+                                                selection: $selectedAlarm.withDefault(Date()),
                                                 in: Date()...,
                                                 displayedComponents: [.date, .hourAndMinute]
                                             )
@@ -234,6 +236,7 @@ struct MakeTodoView: View {
                                                 if #available(iOS 26.0, *) {
                                                     Button(role: .destructive) {
                                                         contentAlarm = Date()
+                                                        selectedAlarm = contentAlarm
                                                         alarmDataisEmpty = true
                                                         alarmisActive.toggle()
                                                     } label: {
@@ -242,6 +245,7 @@ struct MakeTodoView: View {
                                                 } else {
                                                     Button {
                                                         contentAlarm = Date()
+                                                        selectedAlarm = contentAlarm
                                                         alarmDataisEmpty = true
                                                         alarmisActive.toggle()
                                                     } label: {
@@ -255,11 +259,13 @@ struct MakeTodoView: View {
                                                 if #available(iOS 26.0, *) {
                                                     Button(role: .confirm) {
                                                         alarmDataisEmpty = false
+                                                        contentAlarm = selectedAlarm
                                                         alarmisActive.toggle()
                                                     }
                                                 } else {
                                                     Button {
                                                         alarmDataisEmpty = false
+                                                        contentAlarm = selectedAlarm
                                                         alarmisActive.toggle()
                                                     } label: {
                                                         Text("완료")
@@ -269,7 +275,8 @@ struct MakeTodoView: View {
                                         }
                                         .presentationDetents([.height(CGFloat(380))])
                                     }
-                                })
+                                }
+                                )
                                 
                                 Divider()
                                     .padding(.horizontal, 20)

--- a/PhotoTodo/MakeTodoView.swift
+++ b/PhotoTodo/MakeTodoView.swift
@@ -213,35 +213,62 @@ struct MakeTodoView: View {
                                 }
                                 .buttonStyle(.plain)
                                 .sheet(isPresented: $alarmisActive, content: {
-                                    VStack{
-                                        HStack{
-                                            Button(action: {
-                                                contentAlarm = Date()
-                                                alarmDataisEmpty = true
-                                                alarmisActive.toggle()
-                                            }, label: {
-                                                Text("리셋")
-                                            })
+                                    NavigationStack {
+                                        VStack {
+                                            DatePicker(
+                                                "Select Date",
+                                                selection: $contentAlarm.withDefault(Date()),
+                                                in: Date()...,
+                                                displayedComponents: [.date, .hourAndMinute]
+                                            )
+                                            .labelsHidden()
+                                            .datePickerStyle(.wheel)
+                                            
                                             Spacer()
-                                            Button(action: {
-                                                alarmDataisEmpty = false
-                                                alarmisActive.toggle()
-                                            }, label: {
-                                                Text("완료")
-                                            })
                                         }
-                                        
-                                        DatePicker(
-                                            "Select Date",
-                                            selection: $contentAlarm.withDefault(Date()),
-                                            in: Date()...,
-                                            displayedComponents: [.date, .hourAndMinute]
-                                        )
-                                        .labelsHidden()
-                                        .datePickerStyle(.wheel)
+                                        .padding()
+                                        .navigationTitle("알림")
+                                        .navigationBarTitleDisplayMode(.inline)
+                                        .toolbar {
+                                            ToolbarItem(placement: .topBarLeading) {
+                                                if #available(iOS 26.0, *) {
+                                                    Button(role: .destructive) {
+                                                        contentAlarm = Date()
+                                                        alarmDataisEmpty = true
+                                                        alarmisActive.toggle()
+                                                    } label: {
+                                                        Text("리셋")
+                                                    }
+                                                } else {
+                                                    Button {
+                                                        contentAlarm = Date()
+                                                        alarmDataisEmpty = true
+                                                        alarmisActive.toggle()
+                                                    } label: {
+                                                        Text("리셋")
+                                                            .foregroundStyle(.red)
+                                                    }
+                                                }
+                                            }
+                                            
+                                            ToolbarItem(placement: .topBarTrailing) {
+                                                if #available(iOS 26.0, *) {
+                                                    Button(role: .confirm) {
+                                                        alarmDataisEmpty = false
+                                                        alarmisActive.toggle()
+                                                    }
+                                                } else {
+                                                    Button {
+                                                        alarmDataisEmpty = false
+                                                        alarmisActive.toggle()
+                                                    } label: {
+                                                        Text("완료")
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        .presentationDetents([.height(CGFloat(380))])
                                     }
-                                    .padding()
-                                    .presentationDetents([.height(CGFloat(300))])
                                 })
                                 
                                 Divider()

--- a/PhotoTodo/TodoGridView.swift
+++ b/PhotoTodo/TodoGridView.swift
@@ -273,7 +273,7 @@ struct TodoGridView: View {
                             alarmSetting.toggle()
                         } label: {
                             HStack {
-                                Text("정기 알람 설정")
+                                Text("정기 알림 설정")
                                 Image(systemName: "alarm")
                             }
                         }

--- a/PhotoTodo/TodoItemView.swift
+++ b/PhotoTodo/TodoItemView.swift
@@ -175,8 +175,8 @@ struct TodoItemView: View {
         
         var id: String? = nil
         if alarmDataisEmpty != nil && !alarmDataisEmpty! {
-            print("알람 데이터 있음")
-            // 알람 생성
+            print("알림 데이터 있음")
+            // 알림 생성
             let calendar = Calendar.current
             let year = calendar.component(.year, from: contentAlarm ?? .now)
             let month = calendar.component(.month, from: contentAlarm ?? .now)
@@ -184,10 +184,10 @@ struct TodoItemView: View {
             let hour = calendar.component(.hour, from: contentAlarm ?? .now)
             let minute = calendar.component(.minute, from: contentAlarm ?? .now)
             
-            // Notification 알람 생성 및 id Todo에 저장하기
+            // Notification 알림 생성 및 id Todo에 저장하기
             id = manager.makeTodoNotification(year: year, month: month, day: day, hour: hour, minute: minute)
         } else {
-            print("알람 데이터 없음")
+            print("알림 데이터 없음")
             contentAlarm = nil
             alarmDataisEmpty = true
         }


### PR DESCRIPTION
## 변경사항
- 알림 생성 시 시트에서 "완료"버튼을 누르지 않았음에도 값이 선택되는 버그가 있었습니다. "완료"를 눌렀을 때에만 알림 시간이 설정되도록 변경하였습니다.
- "완료"버튼에 iOS26 디자인을 적용하였습니다.

## 비교
|수정 전|수정 후|
|---|---|
|<video src = "https://github.com/user-attachments/assets/2dd0b268-3da3-4411-afa7-789a32c22363">|<video src = "https://github.com/user-attachments/assets/b2fb192e-a1af-4f5b-b601-0168de408d12">|

