### PR TITLE
fix: 폴더 목록 스와이프와 스크롤 제스처 충돌 개선

### DIFF
--- a/PhotoTodo.xcodeproj/project.pbxproj
+++ b/PhotoTodo.xcodeproj/project.pbxproj
@@ -550,19 +550,19 @@
 				INFOPLIST_FILE = PhotoTodo/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSCameraUsageDescription = "TodoItem을 업로드하기 위해 카메라 사용이 필요합니다";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진을 저장하기 위해 권한이 필요합니다";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진을 가져오기 위해 권한이 필요합니다";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.10;
+				MARKETING_VERSION = 1.0.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -591,19 +591,19 @@
 				INFOPLIST_FILE = PhotoTodo/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSCameraUsageDescription = "TodoItem을 업로드하기 위해 카메라 사용이 필요합니다";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진을 저장하기 위해 권한이 필요합니다";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진을 가져오기 위해 권한이 필요합니다";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.10;
+				MARKETING_VERSION = 1.0.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -633,7 +633,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo.ShareImage";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -664,7 +664,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "PhotoTodo-com.2024-MC3-A05-team5.PhotoTodo.ShareImage";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PhotoTodo/FolderRowView.swift
+++ b/PhotoTodo/FolderRowView.swift
@@ -120,7 +120,14 @@ private struct HorizontalPanGestureInstaller: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> UIView {
-        let markerView = UIView(frame: .zero)
+        let markerView = HierarchyTrackingView(frame: .zero)
+        let coordinator = context.coordinator
+
+        markerView.onHierarchyChange = { [weak coordinator] view in
+            DispatchQueue.main.async {
+                coordinator?.attachIfNeeded(from: view)
+            }
+        }
         markerView.isUserInteractionEnabled = false
         return markerView
     }
@@ -137,6 +144,7 @@ private struct HorizontalPanGestureInstaller: UIViewRepresentable {
         _ uiView: UIView,
         coordinator: Coordinator
     ) {
+        (uiView as? HierarchyTrackingView)?.onHierarchyChange = nil
         coordinator.deactivate()
     }
 
@@ -162,13 +170,17 @@ private struct HorizontalPanGestureInstaller: UIViewRepresentable {
 
         func attachIfNeeded(from markerView: UIView) {
             guard isActive,
-                  targetView == nil,
-                  let cellContentView = markerView.enclosingListCellContentView else {
+                  let gestureTargetView = markerView.gestureTargetView else {
                 return
             }
 
-            targetView = cellContentView
-            cellContentView.addGestureRecognizer(panGesture)
+            guard targetView !== gestureTargetView else {
+                return
+            }
+
+            targetView?.removeGestureRecognizer(panGesture)
+            targetView = gestureTargetView
+            gestureTargetView.addGestureRecognizer(panGesture)
         }
 
         func deactivate() {
@@ -219,8 +231,18 @@ private struct HorizontalPanGestureInstaller: UIViewRepresentable {
     }
 }
 
+private final class HierarchyTrackingView: UIView {
+    var onHierarchyChange: ((UIView) -> Void)?
+
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        onHierarchyChange?(self)
+    }
+}
+
 private extension UIView {
-    var enclosingListCellContentView: UIView? {
+    var gestureTargetView: UIView? {
+        let fallbackView = superview
         var candidate = superview
 
         while let view = candidate {
@@ -235,7 +257,7 @@ private extension UIView {
             candidate = view.superview
         }
 
-        return nil
+        return fallbackView
     }
 }
 

--- a/PhotoTodo/FolderRowView.swift
+++ b/PhotoTodo/FolderRowView.swift
@@ -1,109 +1,239 @@
 import SwiftUI
 
 struct FolderRowView<Content: View>: View {
-  init(
-    actions: [Action],
-    @ViewBuilder content: () -> Content
-  ) {
-    self.actions = actions
-    self.content = content()
-  }
+    init(
+        actions: [Action],
+        @ViewBuilder content: () -> Content
+    ) {
+        self.actions = actions
+        self.content = content()
+    }
 
-  var content: Content
+    var content: Content
 
-  @State private var offset: CGFloat = 0
-  @State private var startOffset: CGFloat = 0
-  @State private var isDragging = false
-  @State private var isTriggered = false
+    @State private var offset: CGFloat = 0
+    @State private var startOffset: CGFloat = 0
+    @State private var isTriggered = false
 
-  let triggerThreshhold: CGFloat = -250
-  let expansionThreshhold: CGFloat = -60
-  let actions: [Action]
+    let triggerThreshhold: CGFloat = -250
+    let expansionThreshhold: CGFloat = -60
+    let actions: [Action]
 
-  var expansionOffset: CGFloat { CGFloat(actions.count) * -60 }
+    var expansionOffset: CGFloat { CGFloat(actions.count) * -60 }
 
-  var dragGesture: some Gesture {
-    DragGesture()
-      .onChanged { value in
-          if value.translation.width > 0 {
-                  withAnimation(.interactiveSpring) {
-                      offset = 0
-                  }
-                  return
-              }
+    var body: some View {
+        content
+            .offset(x: offset)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .overlay(alignment: .trailing) {
+                ZStack(alignment: .trailing) {
+                    ForEach(Array(actions.enumerated()), id: \.offset) { index, action in
+                        let width = isTriggered ? -offset : -offset * CGFloat(actions.count - index) / CGFloat(actions.count)
 
-          
-        if !isDragging {
-          startOffset = offset
-          isDragging = true
-        }
-          
-        withAnimation(.interactiveSpring) {
-          offset = startOffset + value.translation.width
-        }
-        
-        isTriggered = offset < triggerThreshhold
-      }
-      .onEnded { value in
-        isDragging = false
+                        ActionButton(
+                            action: action,
+                            width: width,
+                            dismiss: { withAnimation { offset = 0 } },
+                            onActionTriggered: {
+                                withAnimation {
+                                    offset = -UIScreen.main.bounds.width + 30
+                                    isTriggered = true
+                                }
+                            }
+                        )
+                    }
+                }
+                .animation(.spring, value: isTriggered)
+                .onChange(of: isTriggered) {
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                }
+            }
+            .background {
+                HorizontalPanGestureInstaller(
+                    isOpen: offset != 0,
+                    onBegan: {
+                        startOffset = offset
+                    },
+                    onChanged: { translationX in
+                        offset = min(0, startOffset + translationX)
+                        isTriggered = offset < triggerThreshhold
+                    },
+                    onEnded: { translationX, velocityX in
+                        finishSwipe(
+                            translationX: translationX,
+                            velocityX: velocityX
+                        )
+                    },
+                    onCancelled: {
+                        withAnimation {
+                            offset = startOffset
+                        }
+                        isTriggered = false
+                    }
+                )
+            }
+    }
 
-        if let action = actions.last, isTriggered {
-          withAnimation {
-            offset = -UIScreen.main.bounds.width + 30
-              //화면 왼쪽의 패딩만큼 더 가야 함
-              //리스트의 패딩값이 조정된다면 이부분도 조정 필요
-          }
-          action.action {
+    private func finishSwipe(
+        translationX: CGFloat,
+        velocityX: CGFloat
+    ) {
+        if let action = actions.last,
+           offset < triggerThreshhold {
             withAnimation {
-              offset = 0 // Reset after action completes
+                offset = -UIScreen.main.bounds.width + 30
             }
-          }
+
+            action.action {
+                withAnimation {
+                    offset = 0
+                }
+            }
         } else {
-          withAnimation {
-            if value.predictedEndTranslation.width < expansionThreshhold {
-              offset = expansionOffset
-            } else {
-              offset = 0
+            // UIKit에는 predictedEndTranslation이 없으므로 현재 속도로 투영한다.
+            let projectedOffset = startOffset
+                + translationX
+                + velocityX * 0.2
+
+            withAnimation {
+                offset = projectedOffset < expansionThreshhold
+                    ? expansionOffset
+                    : 0
             }
-          }
         }
 
         isTriggered = false
-      }
-  }
+    }
+}
 
-  var body: some View {
-    content
-      .offset(x: offset)
-      .padding()
-      .frame(maxWidth: .infinity)
-      .contentShape(Rectangle())
-      .overlay(alignment: .trailing) {
-        ZStack(alignment: .trailing) {
-          ForEach(Array(actions.enumerated()), id: \.offset) { index, action in
-            let isDefault = index == actions.count - 1
-            let width = isTriggered ? -offset : -offset * CGFloat(actions.count - index) / CGFloat(actions.count)
+private struct HorizontalPanGestureInstaller: UIViewRepresentable {
+    let isOpen: Bool
+    let onBegan: () -> Void
+    let onChanged: (CGFloat) -> Void
+    let onEnded: (CGFloat, CGFloat) -> Void
+    let onCancelled: () -> Void
 
-            ActionButton(
-              action: action,
-              width: width,
-              dismiss: { withAnimation { offset = 0 } },
-              onActionTriggered: {
-                  withAnimation {
-                      offset = -UIScreen.main.bounds.width + 30
-                      isTriggered = true
-                  }
-              }
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let markerView = UIView(frame: .zero)
+        markerView.isUserInteractionEnabled = false
+        return markerView
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.parent = self
+
+        DispatchQueue.main.async {
+            context.coordinator.attachIfNeeded(from: uiView)
+        }
+    }
+
+    static func dismantleUIView(
+        _ uiView: UIView,
+        coordinator: Coordinator
+    ) {
+        coordinator.detach()
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var parent: HorizontalPanGestureInstaller
+
+        private weak var targetView: UIView?
+        private lazy var panGesture: UIPanGestureRecognizer = {
+            let gesture = UIPanGestureRecognizer(
+                target: self,
+                action: #selector(handlePan(_:))
             )
-          }
+            gesture.delegate = self
+            gesture.cancelsTouchesInView = true
+            gesture.maximumNumberOfTouches = 1
+            return gesture
+        }()
+
+        init(parent: HorizontalPanGestureInstaller) {
+            self.parent = parent
         }
-        .animation(.spring, value: isTriggered)
-        .onChange(of: isTriggered) {
-          UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+
+        func attachIfNeeded(from markerView: UIView) {
+            guard targetView == nil,
+                  let cellContentView = markerView.enclosingListCellContentView else {
+                return
+            }
+
+            targetView = cellContentView
+            cellContentView.addGestureRecognizer(panGesture)
         }
-      }
-      .highPriorityGesture(dragGesture)
-  }
+
+        func detach() {
+            targetView?.removeGestureRecognizer(panGesture)
+            targetView = nil
+        }
+
+        func gestureRecognizerShouldBegin(
+            _ gestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            guard let pan = gestureRecognizer as? UIPanGestureRecognizer else {
+                return false
+            }
+
+            let velocity = pan.velocity(in: pan.view)
+            guard abs(velocity.x) > abs(velocity.y) else {
+                return false
+            }
+
+            return parent.isOpen || velocity.x < 0
+        }
+
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            true
+        }
+
+        @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+            let translationX = gesture.translation(in: gesture.view).x
+            let velocityX = gesture.velocity(in: gesture.view).x
+
+            switch gesture.state {
+            case .began:
+                parent.onBegan()
+            case .changed:
+                parent.onChanged(translationX)
+            case .ended:
+                parent.onEnded(translationX, velocityX)
+            case .cancelled, .failed:
+                parent.onCancelled()
+            default:
+                break
+            }
+        }
+    }
+}
+
+private extension UIView {
+    var enclosingListCellContentView: UIView? {
+        var candidate = superview
+
+        while let view = candidate {
+            if let cell = view as? UICollectionViewCell {
+                return cell.contentView
+            }
+
+            if let cell = view as? UITableViewCell {
+                return cell.contentView
+            }
+
+            candidate = view.superview
+        }
+
+        return nil
+    }
 }
 
 #Preview {

--- a/PhotoTodo/FolderRowView.swift
+++ b/PhotoTodo/FolderRowView.swift
@@ -208,7 +208,11 @@ private struct HorizontalPanGestureInstaller: UIViewRepresentable {
             _ gestureRecognizer: UIGestureRecognizer,
             shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
         ) -> Bool {
-            true
+            guard let scrollView = otherGestureRecognizer.view as? UIScrollView else {
+                return false
+            }
+
+            return otherGestureRecognizer === scrollView.panGestureRecognizer
         }
 
         @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {

--- a/PhotoTodo/FolderRowView.swift
+++ b/PhotoTodo/FolderRowView.swift
@@ -137,12 +137,13 @@ private struct HorizontalPanGestureInstaller: UIViewRepresentable {
         _ uiView: UIView,
         coordinator: Coordinator
     ) {
-        coordinator.detach()
+        coordinator.deactivate()
     }
 
     final class Coordinator: NSObject, UIGestureRecognizerDelegate {
         var parent: HorizontalPanGestureInstaller
 
+        private var isActive = true
         private weak var targetView: UIView?
         private lazy var panGesture: UIPanGestureRecognizer = {
             let gesture = UIPanGestureRecognizer(
@@ -160,7 +161,8 @@ private struct HorizontalPanGestureInstaller: UIViewRepresentable {
         }
 
         func attachIfNeeded(from markerView: UIView) {
-            guard targetView == nil,
+            guard isActive,
+                  targetView == nil,
                   let cellContentView = markerView.enclosingListCellContentView else {
                 return
             }
@@ -169,7 +171,8 @@ private struct HorizontalPanGestureInstaller: UIViewRepresentable {
             cellContentView.addGestureRecognizer(panGesture)
         }
 
-        func detach() {
+        func deactivate() {
+            isActive = false
             targetView?.removeGestureRecognizer(panGesture)
             targetView = nil
         }


### PR DESCRIPTION
## 변경 배경

폴더 목록에서 커스텀 스와이프 제스처가 세로 스크롤과 충돌하는 문제를 개선했습니다.

## 주요 변경 사항

- 수평 이동이 세로 이동보다 클 때만 스와이프 시작
- `UIScrollView`의 실제 스크롤 pan과만 동시 인식 허용
- 내비게이션 및 다른 수평 제스처와의 동시 실행 차단
- 화면에서 제거된 셀에 제스처가 다시 연결되지 않도록 생명주기 처리
- List 셀 재사용 및 계층 이동 시 recognizer를 올바른 셀에 재연결
- List 셀을 찾을 수 없는 환경에서는 SwiftUI 컨테이너를 fallback으로 사용
- 프로젝트 설정 업데이트

## 검증

- `PhotoTodo` Debug 시뮬레이터 빌드 성공
- 기존 세로 스크롤 동작 유지
- 왼쪽 스와이프 액션 및 오른쪽 닫기 동작 유지

## 확인이 필요한 동작

- 목록을 빠르게 스크롤한 후 각 행의 스와이프 동작
- 스와이프 도중 세로 스크롤 전환
- 삭제 확인 Alert의 취소 및 삭제 동작
- 열린 행을 오른쪽으로 스와이프해 닫는 동작